### PR TITLE
Don't use high baudrates when not available

### DIFF
--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -85,11 +85,13 @@ public:
         BAUD_1152000 = B1152000, 
         BAUD_1500000 = B1500000,
         BAUD_2000000 = B2000000,
+#if __MAX_BAUD > B2000000
         BAUD_2500000 = B2500000,
         BAUD_3000000 = B3000000,
         BAUD_3500000 = B3500000,
         BAUD_4000000 = B4000000,
 #endif
+#endif /* __linux__ */
         BAUD_DEFAULT = BAUD_57600
     } ;
 

--- a/src/SerialStreamBuf.h
+++ b/src/SerialStreamBuf.h
@@ -85,11 +85,13 @@ extern "C++"
                 BAUD_1152000 = SerialPort::BAUD_1152000, 
                 BAUD_1500000 = SerialPort::BAUD_1500000, 
                 BAUD_2000000 = SerialPort::BAUD_2000000, 
+#if __MAX_BAUD > B2000000
                 BAUD_2500000 = SerialPort::BAUD_2500000, 
                 BAUD_3000000 = SerialPort::BAUD_3000000, 
                 BAUD_3500000 = SerialPort::BAUD_3500000, 
                 BAUD_4000000 = SerialPort::BAUD_4000000, 
 #endif
+#endif /* __linux__ */
                 BAUD_DEFAULT = SerialPort::BAUD_DEFAULT,
                 BAUD_INVALID = -1
             } ;


### PR DESCRIPTION
On certain architectures (namely Sparc), the maximum baud rate exposed
by the kernel headers is B2000000. Therefore, the current libserial
code doesn't build for the Sparc and Sparc64 architectures due to
this.

In order to address this problem, this patch tests the value of
__MAX_BAUD. If it's higher than B2000000 then we assume we're on an
architecture that supports all baud rates up to B4000000. Otherwise,
we simply don't support the baud rates above B2000000.

Fixes build failures such as:

./SerialPort.h:88:24: error: 'B2500000' was not declared in this scope
         BAUD_2500000 = B2500000,

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>