### PR TITLE
Make the Python bindings build conditional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,9 @@
-SUBDIRS=src doc examples sip
+SUBDIRS=src doc examples
+
+if PYTHON
+SUBDIRS += sip
+endif
+
 ACLOCAL_AMFLAGS=-I m4
 
 EXTRA_DIST = doxygen.conf.in Makefile.dist libserial.spec libserial.pc

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,10 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_C_INLINE
 
+AC_ARG_WITH([python],
+	AS_HELP_STRING([--without-python], [Disable Python bindings]),
+	[], [with_python=yes])
+AM_CONDITIONAL([PYTHON], [test "${with_python}" != "no"])
 
 AC_OUTPUT([Makefile
 doxygen.conf


### PR DESCRIPTION
In some situations, building the Python bindings may not be desirable
or even possible, for example in the context of cross-compiled
embedded systems, Python may not even be available on the target
platform.

In order to address this, this commit adds a
--with-python/--without-python option to the configure script, which
allows to specify whether Python bindings should be built or not. Of
course, in order to preserve the current behavior, the Python bindings
are built by default (if neither --with-python nor --without-python is
passed).

This change would for example be useful for embedded Linux build
systems such as Buildroot (http://buildroot.org).

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>