### PR TITLE
Fixed undefined behavior/illegal instruction crash

### DIFF
--- a/src/SerialStreamBuf.cc
+++ b/src/SerialStreamBuf.cc
@@ -287,7 +287,7 @@ SerialStreamBuf::SetParametersToDefault()
 const SerialStreamBuf::BaudRateEnum
 SerialStreamBuf::SetBaudRate(const BaudRateEnum baud_rate) 
 {
-    mImpl->SetBaudRate( baud_rate ) ;
+    return mImpl->SetBaudRate( baud_rate ) ;
 }
 
 const SerialStreamBuf::BaudRateEnum
@@ -531,7 +531,7 @@ SerialStreamBuf::Implementation::SetParametersToDefault()
     //
     // Character size. 
     //
-    if( -1 == SetCharSize(DEFAULT_CHAR_SIZE) ) {
+    if( CHAR_SIZE_INVALID == SetCharSize(DEFAULT_CHAR_SIZE) ) {
         return -1 ;
     }
     //
@@ -543,13 +543,13 @@ SerialStreamBuf::Implementation::SetParametersToDefault()
     //
     // Parity
     //
-    if( -1 == SetParity(DEFAULT_PARITY) ) {
+    if( PARITY_INVALID == SetParity(DEFAULT_PARITY) ) {
         return -1 ;
     }
     //
     // Flow control
     //
-    if( -1 == SetFlowControl(DEFAULT_FLOW_CONTROL) ) {
+    if( FLOW_CONTROL_INVALID == SetFlowControl(DEFAULT_FLOW_CONTROL) ) {
         return -1 ;
     }
     //


### PR DESCRIPTION
If compiled with clang 3.4 on x86-64, SetBaudRate would crash with SIGILL
because of the ud2 instruction inserted because of the missing return
statement

* SetBaudRate was not actually returning anything, which doesn't work
with some compiler/platform combinations

Also fixed the following warnings:

* Error checking on SetParity, SetBaudRate and SetFlowControl was not
using the right enumeration values during default