### PR TITLE
Serial Stream Multi-Thread unit test added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,9 @@ ADD_DEFINITIONS(
   -Wno-long-long  
   -Wno-psabi
   -Wno-variadic-macros
-  #-Wnon-virtual-dtor
+  -Wnon-virtual-dtor
   -Wpointer-arith
-  #-Wundef
+  -Wundef
   -Wuninitialized
   -Wunused-local-typedefs
   -Wwrite-strings
@@ -45,11 +45,6 @@ ADD_DEFINITIONS(
   -pthread
   )
 
-# Uncomment the following lines to compile for 32 bit architectures
-#SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -fms-extensions -m32")
-#SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fms-extensions -m32")
-
-# Uncomment the following lines to compile for 64 bit architectures
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -fms-extensions")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fms-extensions")
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -83,9 +83,8 @@ namespace LibSerial
          * @brief This routine is called by open() in order to
          *        initialize some parameters of the serial port and
          *        setting its parameters to default values.
-         * @return -1 on failure and some other value on success. 
          */
-        int InitializeSerialPort();
+        void InitializeSerialPort();
 
         /**
          * @brief Sets all serial port paramters to their default values.
@@ -424,10 +423,11 @@ namespace LibSerial
         return mImpl->IsOpen();
     }
 
-    int
+    void
     SerialPort::InitializeSerialPort()
     {
-        return mImpl->InitializeSerialPort();
+        mImpl->InitializeSerialPort();
+        return;
     }
 
     void
@@ -756,10 +756,7 @@ namespace LibSerial
         }
 
         // Initialize the serial port. 
-        if (InitializeSerialPort() < 0)
-        {
-            throw std::runtime_error(strerror(errno));
-        }
+        InitializeSerialPort();
 
         return;
     }
@@ -803,7 +800,7 @@ namespace LibSerial
     }
 
     inline
-    int
+    void
     SerialPort::Implementation::InitializeSerialPort()
     {
         // Make sure that the serial port is open.
@@ -819,14 +816,14 @@ namespace LibSerial
                   F_SETFL, 
                   flags | O_NONBLOCK) < 0)
         {
-            return -1;
+            throw std::runtime_error(strerror(errno));
         }
 
         // Flush out any garbage left behind in the buffers associated
         // with the port from any previous operations. 
         if (tcflush(this->mFileDescriptor, TCIOFLUSH) < 0)
         {
-            return -1;
+            throw std::runtime_error(strerror(errno));
         }
 
         // Set up the default configuration for the serial port.
@@ -839,11 +836,11 @@ namespace LibSerial
                          F_SETFL, 
                          flags & ~O_NONBLOCK) < 0)
         {
-            return -1;
+            throw std::runtime_error(strerror(errno));
         }
 
         // Initialization was successful.
-        return 0;
+        return;
     }
 
     inline

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -35,11 +35,11 @@
 namespace
 {
     /**
-     * Return the difference between the two specified timeval values.
-     * This method subtracts secondOperand from firstOperand and returns
-     * the result as a timeval. The time represented by firstOperand must
-     * be later than the time represented by secondOperand. Otherwise,
-     * the result of this operator may be undefined.
+     * @brief Calculates the difference between the two specified timeval values.
+     *        This method subtracts secondOperand from firstOperand and returns
+     *        the result as a timeval. The time represented by firstOperand must
+     *        be later than the time represented by secondOperand.
+     * @return Returns the difference between the two specified timeval values.
      */
     const timeval
     operator-(const timeval& firstOperand,
@@ -50,6 +50,13 @@ namespace
          *        platform uses unsigned values for storing tv_sec and tv_usec
          *        members of struct timeval.
          */
+        if (firstOperand.tv_sec <= secondOperand.tv_sec &&
+            firstOperand.tv_usec < secondOperand.tv_usec)
+        {
+            // Throw and invalid argument exception if the firstOperand
+            // was an earlier time value than the secondOperand.
+            throw std::invalid_argument(strerror(errno));
+        }
 
         timeval result;
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -43,7 +43,31 @@ namespace
      */
     const timeval
     operator-(const timeval& firstOperand,
-              const timeval& secondOperand);
+              const timeval& secondOperand)
+    {
+        /**
+         * @NOTE: This implementation may result in undefined behavior if the
+         *        platform uses unsigned values for storing tv_sec and tv_usec
+         *        members of struct timeval.
+         */
+
+        timeval result;
+
+        // Take the difference of individual members of the two operands.
+        result.tv_sec  = firstOperand.tv_sec - secondOperand.tv_sec;
+        result.tv_usec = firstOperand.tv_usec - secondOperand.tv_usec;
+
+        // If abs(result.tv_usec) is larger than MICROSECONDS_PER_SECOND,
+        // then increment/decrement result.tv_sec accordingly.
+        if (std::abs(result.tv_usec) > LibSerial::MICROSECONDS_PER_SEC)
+        {
+            int num_of_seconds = (result.tv_usec / LibSerial::MICROSECONDS_PER_SEC);
+            result.tv_sec  += num_of_seconds;
+            result.tv_usec -= (LibSerial::MICROSECONDS_PER_SEC * num_of_seconds);
+        }
+        
+        return result;
+    }
 }
 
 namespace LibSerial 
@@ -2093,36 +2117,5 @@ namespace LibSerial
         }
 
         return (serial_port_state & modemLine);
-    }
-}
-
-namespace
-{
-    const timeval
-    operator-(const timeval& firstOperand,
-              const timeval& secondOperand)
-    {
-        /**
-         * @NOTE: This implementation may result in undefined behavior if the
-         *        platform uses unsigned values for storing tv_sec and tv_usec
-         *        members of struct timeval.
-         */
-
-        timeval result;
-
-        // Take the difference of individual members of the two operands.
-        result.tv_sec  = firstOperand.tv_sec - secondOperand.tv_sec;
-        result.tv_usec = firstOperand.tv_usec - secondOperand.tv_usec;
-
-        // If abs(result.tv_usec) is larger than MICROSECONDS_PER_SECOND,
-        // then increment/decrement result.tv_sec accordingly.
-        if (std::abs(result.tv_usec) > LibSerial::MICROSECONDS_PER_SEC)
-        {
-            int num_of_seconds = (result.tv_usec / LibSerial::MICROSECONDS_PER_SEC);
-            result.tv_sec  += num_of_seconds;
-            result.tv_usec -= (LibSerial::MICROSECONDS_PER_SEC * num_of_seconds);
-        }
-        
-        return result;
     }
 }

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -35,11 +35,11 @@
 namespace
 {
     /**
-     * @brief Calculates the difference between the two specified timeval values.
-     *        This method subtracts secondOperand from firstOperand and returns
-     *        the result as a timeval. The time represented by firstOperand must
-     *        be later than the time represented by secondOperand.
-     * @return Returns the difference between the two specified timeval values.
+     * Return the difference between the two specified timeval values.
+     * This method subtracts secondOperand from firstOperand and returns
+     * the result as a timeval. The time represented by firstOperand must
+     * be later than the time represented by secondOperand. Otherwise,
+     * the result of this operator may be undefined.
      */
     const timeval
     operator-(const timeval& firstOperand,
@@ -50,13 +50,6 @@ namespace
          *        platform uses unsigned values for storing tv_sec and tv_usec
          *        members of struct timeval.
          */
-        if (firstOperand.tv_sec <= secondOperand.tv_sec &&
-            firstOperand.tv_usec < secondOperand.tv_usec)
-        {
-            // Throw and invalid argument exception if the firstOperand
-            // was an earlier time value than the secondOperand.
-            throw std::invalid_argument(strerror(errno));
-        }
 
         timeval result;
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -232,23 +232,23 @@ namespace LibSerial
 
         /**
          * @brief Writes a single byte to the serial port.
-         * @param dataByte The byte to be written to the serial port.
+         * @param charbuffer The byte to be written to the serial port.
          */
-        void WriteByte(const unsigned char dataByte);
+        void WriteByte(const unsigned char charbuffer);
+
+        /**
+         * @brief Writes a DataBuffer vector to the serial port.
+         * @param charBuffer The data to be written to the serial port.
+         * @param charBufferSize The number of bytes to be written to the serial port.
+         */
+        void Write(const unsigned char* charBuffer,
+                   const unsigned int   charBufferSize);
 
         /**
          * @brief Writes a DataBuffer vector to the serial port.
          * @param dataBuffer The DataBuffer vector to be written to the serial port.
          */
         void Write(const SerialPort::DataBuffer& dataBuffer);
-
-        /**
-         * @brief Writes a DataBuffer vector to the serial port.
-         * @param dataBuffer The DataBuffer vector to be written to the serial port.
-         * @param bufferSize The number of bytes to be written to the serial port.
-         */
-        void Write(const unsigned char* dataBuffer,
-                   const unsigned int   bufferSize);
 
         /**
          * @brief Sets the serial port DTR line status.
@@ -1766,7 +1766,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::WriteByte(const unsigned char dataByte)
+    SerialPort::Implementation::WriteByte(const unsigned char charBuffer)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1774,9 +1774,43 @@ namespace LibSerial
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
         }
 
-        // Write the byte to the serial port.
-        this->Write(&dataByte,
+        this->Write(&charBuffer,
                     1);
+
+        return;
+    }
+
+    inline
+    void
+    SerialPort::Implementation::Write(const unsigned char* charBuffer,
+                                      const unsigned int   charBufferSize)
+    {
+        // Throw an exception if the serial port is not open.
+        if (!this->IsOpen())
+        {
+            throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
+        }
+
+        // Write the data to the serial port. Keep retrying if EAGAIN
+        // error is received and EWOULDBLOCK is not received.
+        int num_of_bytes_written = -1;
+        
+        do
+        {
+            num_of_bytes_written = write(mFileDescriptor,
+                                         charBuffer,
+                                         charBufferSize);
+        }
+        while (num_of_bytes_written <= 0 &&
+               errno == EAGAIN &&
+               errno != EWOULDBLOCK);
+
+        if (num_of_bytes_written < 0 ||
+            num_of_bytes_written < (int)charBufferSize)
+        {
+            throw std::runtime_error(strerror(errno));
+        }
+
         return;
     }
 
@@ -1827,40 +1861,6 @@ namespace LibSerial
 
         // Free the allocated memory.
         delete [] local_buffer;
-        return;
-    }
-
-    inline
-    void
-    SerialPort::Implementation::Write(const unsigned char* dataBuffer,
-                                      const unsigned int   bufferSize)
-    {
-        // Throw an exception if the serial port is not open.
-        if (!this->IsOpen())
-        {
-            throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
-        }
-
-        // Write the data to the serial port. Keep retrying if EAGAIN
-        // error is received and EWOULDBLOCK is not received.
-        int num_of_bytes_written = -1;
-        
-        do
-        {
-            num_of_bytes_written = write(mFileDescriptor,
-                                         dataBuffer,
-                                         bufferSize);
-        }
-        while (num_of_bytes_written < 0 &&
-               errno == EAGAIN &&
-               errno != EWOULDBLOCK);
-
-        if (num_of_bytes_written < 0 ||
-            num_of_bytes_written < (int)bufferSize)
-        {
-            throw std::runtime_error(strerror(errno));
-        }
-
         return;
     }
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -32,44 +32,6 @@
 #include <unistd.h>
 
 
-namespace
-{
-    /**
-     * Return the difference between the two specified timeval values.
-     * This method subtracts secondOperand from firstOperand and returns
-     * the result as a timeval. The time represented by firstOperand must
-     * be later than the time represented by secondOperand. Otherwise,
-     * the result of this operator may be undefined.
-     */
-    const timeval
-    operator-(const timeval& firstOperand,
-              const timeval& secondOperand)
-    {
-        /**
-         * @NOTE: This implementation may result in undefined behavior if the
-         *        platform uses unsigned values for storing tv_sec and tv_usec
-         *        members of struct timeval.
-         */
-
-        timeval result;
-
-        // Take the difference of individual members of the two operands.
-        result.tv_sec  = firstOperand.tv_sec - secondOperand.tv_sec;
-        result.tv_usec = firstOperand.tv_usec - secondOperand.tv_usec;
-
-        // If abs(result.tv_usec) is larger than MICROSECONDS_PER_SECOND,
-        // then increment/decrement result.tv_sec accordingly.
-        if (std::abs(result.tv_usec) > LibSerial::MICROSECONDS_PER_SEC)
-        {
-            int num_of_seconds = (result.tv_usec / LibSerial::MICROSECONDS_PER_SEC);
-            result.tv_sec  += num_of_seconds;
-            result.tv_usec -= (LibSerial::MICROSECONDS_PER_SEC * num_of_seconds);
-        }
-        
-        return result;
-    }
-}
-
 namespace LibSerial 
 {
     class SerialPort::Implementation : public PosixSignalHandler
@@ -1558,7 +1520,7 @@ namespace LibSerial
                 }
 
                 // Obtain the elapsed time.
-                elapsed_time = current_time - entry_time;
+                timersub(&current_time, &entry_time, &elapsed_time);
 
                 // Calculate the elapsed number of milliseconds.
                 elapsed_ms = (elapsed_time.tv_sec  * MILLISECONDS_PER_SEC +
@@ -1637,7 +1599,7 @@ namespace LibSerial
                 }
 
                 // Obtain the elapsed time.
-                elapsed_time = current_time - entry_time;
+                timersub(&current_time, &entry_time, &elapsed_time);
 
                 // Calculate the elapsed number of milliseconds.
                 elapsed_ms = (elapsed_time.tv_sec  * MILLISECONDS_PER_SEC +
@@ -1702,7 +1664,7 @@ namespace LibSerial
             }
 
             // Obtain the total elapsed time.
-            elapsed_time = current_time - entry_time;
+            timersub(&current_time, &entry_time, &elapsed_time);
 
             // Calculate the elapsed number of milliseconds.
             elapsed_ms = (elapsed_time.tv_sec  * MILLISECONDS_PER_SEC +
@@ -1778,7 +1740,7 @@ namespace LibSerial
             }
 
             // Obtain the elapsed time.
-            elapsed_time = current_time - entry_time;
+            timersub(&current_time, &entry_time, &elapsed_time);
 
             // Calculate the elapsed number of milliseconds.
             elapsed_ms = (elapsed_time.tv_sec  * MILLISECONDS_PER_SEC +

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -756,7 +756,7 @@ namespace LibSerial
         }
 
         // Initialize the serial port. 
-        if (-1 == InitializeSerialPort())
+        if (InitializeSerialPort() < 0)
         {
             throw std::runtime_error(strerror(errno));
         }
@@ -815,16 +815,16 @@ namespace LibSerial
         // Use non-blocking mode while configuring the serial port. 
         int flags = fcntl(this->mFileDescriptor, F_GETFL, 0);
         
-        if ( -1 == fcntl( this->mFileDescriptor, 
-                         F_SETFL, 
-                         flags | O_NONBLOCK ) )
+        if (fcntl(this->mFileDescriptor, 
+                  F_SETFL, 
+                  flags | O_NONBLOCK) < 0)
         {
             return -1;
         }
 
         // Flush out any garbage left behind in the buffers associated
         // with the port from any previous operations. 
-        if ( -1 == tcflush(this->mFileDescriptor, TCIOFLUSH) )
+        if (tcflush(this->mFileDescriptor, TCIOFLUSH) < 0)
         {
             return -1;
         }
@@ -835,9 +835,9 @@ namespace LibSerial
         // Allow all further communications to happen in blocking mode.
         flags = fcntl(this->mFileDescriptor, F_GETFL, 0);
         
-        if ( -1 == fcntl( this->mFileDescriptor, 
+        if (fcntl( this->mFileDescriptor, 
                          F_SETFL, 
-                         flags & ~O_NONBLOCK ) )
+                         flags & ~O_NONBLOCK) < 0)
         {
             return -1;
         }
@@ -949,7 +949,7 @@ namespace LibSerial
     BaudRate
     SerialPort::Implementation::GetBaudRate()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -985,7 +985,7 @@ namespace LibSerial
     void
     SerialPort::Implementation::SetCharacterSize(const CharacterSize& characterSize)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1037,7 +1037,7 @@ namespace LibSerial
     CharacterSize
     SerialPort::Implementation::GetCharacterSize()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1061,7 +1061,7 @@ namespace LibSerial
     void
     SerialPort::Implementation::SetFlowControl(const FlowControl& flowControlType)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1125,7 +1125,7 @@ namespace LibSerial
     FlowControl
     SerialPort::Implementation::GetFlowControl()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1175,7 +1175,7 @@ namespace LibSerial
     void
     SerialPort::Implementation::SetParity(const Parity& parityType)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1228,7 +1228,7 @@ namespace LibSerial
     Parity
     SerialPort::Implementation::GetParity()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1269,7 +1269,7 @@ namespace LibSerial
     void
     SerialPort::Implementation::SetNumberOfStopBits(const StopBits& numberOfStopBits)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1314,7 +1314,7 @@ namespace LibSerial
     StopBits
     SerialPort::Implementation::GetNumberOfStopBits()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1346,7 +1346,7 @@ namespace LibSerial
     void 
     SerialPort::Implementation::SetVMin(const short vmin)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1384,7 +1384,7 @@ namespace LibSerial
     short 
     SerialPort::Implementation::GetVMin()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1407,7 +1407,7 @@ namespace LibSerial
     void 
     SerialPort::Implementation::SetVTime(const short vtime)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1445,7 +1445,7 @@ namespace LibSerial
     short 
     SerialPort::Implementation::GetVTime() 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1468,7 +1468,7 @@ namespace LibSerial
     bool
     SerialPort::Implementation::IsDataAvailable()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1487,7 +1487,7 @@ namespace LibSerial
                                      const unsigned int      numOfBytes,
                                      const unsigned int      msTimeout)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1569,7 +1569,7 @@ namespace LibSerial
                                      const unsigned int numOfBytes,
                                      const unsigned int msTimeout)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1647,7 +1647,7 @@ namespace LibSerial
     SerialPort::Implementation::ReadByte(unsigned char&     charBuffer,
                                          const unsigned int msTimeout)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1719,6 +1719,12 @@ namespace LibSerial
                                          const char         lineTerminator,
                                          const unsigned int msTimeout)
     {
+        // Throw an exception if the serial port is not open.
+        if (!this->IsOpen())
+        {
+            throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
+        }
+        
         // Clear the data string.
         dataString.clear();
 
@@ -1779,7 +1785,7 @@ namespace LibSerial
     void
     SerialPort::Implementation::WriteByte(const unsigned char dataByte)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1795,7 +1801,7 @@ namespace LibSerial
     void
     SerialPort::Implementation::Write(const SerialPort::DataBuffer& dataBuffer)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1846,7 +1852,7 @@ namespace LibSerial
     SerialPort::Implementation::Write(const unsigned char* dataBuffer,
                                       const unsigned int   bufferSize)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -2011,7 +2017,7 @@ namespace LibSerial
     SerialPort::Implementation::SetModemControlLine(const int  modemLine,
                                                     const bool lineState)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -2051,7 +2057,7 @@ namespace LibSerial
         }
 
         // Check for errors.
-        if (-1 == ioctl_result)
+        if (ioctl_result  < 0)
         {
             throw std::runtime_error(strerror(errno));
         }
@@ -2063,7 +2069,7 @@ namespace LibSerial
     bool
     SerialPort::Implementation::GetModemControlLine(const int modemLine)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -2087,9 +2093,9 @@ namespace LibSerial
         // Use an ioctl() call to get the state of the line.
         int serial_port_state = 0;
         
-        if (-1 == ioctl(mFileDescriptor,
-                        TIOCMGET,
-                        &serial_port_state))
+        if (ioctl(mFileDescriptor,
+                  TIOCMGET,
+                  &serial_port_state) < 0)
         {
             throw std::runtime_error(strerror(errno));
         }

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -1978,11 +1978,6 @@ namespace LibSerial
                 {
                     mInputBuffer.push(next_byte);
                 }
-                else
-                {
-                    pthread_mutex_unlock(&mInputBufferMutex);
-                    break;
-                }
             }
 
             // Release the mutex

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -267,22 +267,19 @@ namespace LibSerial
 
         /**
          * @brief Writes a single byte to the serial port.
-         * @param dataByte The byte to be written to the serial port.
+         * @param charbuffer The byte to be written to the serial port.
          */
-        void WriteByte(const unsigned char dataByte);
+        void WriteByte(const unsigned char charbuffer);
 
         /**
          * @brief Writes a DataBuffer vector to the serial port.
-         * @param dataBuffer The DataBuffer vector to be written to the serial
-         *        port.
+         * @param dataBuffer The DataBuffer vector to be written to the serial port.
          */
-        void Write(const DataBuffer& dataBuffer);
+        void Write(const SerialPort::DataBuffer& dataBuffer);
 
         /**
          * @brief Writes a std::string to the serial port.
          * @param dataString The data string to be written to the serial port.
-         * @throw NotOpen This exception is thrown if this method is called while the serial port is not open.
-         * @throw std::runtime_error This exception is thrown if any standard runtime error is encountered.
          */
         void Write(const std::string& dataString);
 

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -98,9 +98,8 @@ namespace LibSerial
          * @brief This routine is called by open() in order to
          *        initialize some parameters of the serial port and
          *        setting its parameters to default values.
-         * @return -1 on failure and some other value on success. 
          */
-        int InitializeSerialPort();
+        void InitializeSerialPort();
 
         /**
          * @brief Initializes the serial communication parameters to their

--- a/src/SerialPortConstants.h
+++ b/src/SerialPortConstants.h
@@ -43,14 +43,22 @@ namespace LibSerial
     const int MICROSECONDS_PER_MS  =    1000;
     const int MILLISECONDS_PER_SEC =    1000;
     const int MICROSECONDS_PER_SEC = 1000000;
-
+        
     /**
      * @brief The default character buffer size.
+     * @deprecated VMIN and VTIME will not be supported starting
+     *             from version 0.7.0. Methods of SerialPort class
+     *             provide better mechanisms for implementing read
+     *             and write timeouts.
      */
-    static constexpr short VMIN_DEFAULT = 0;
+    static constexpr short VMIN_DEFAULT = 1;
 
     /**
      * @brief The default character buffer timing.
+     * @deprecated VMIN and VTIME will not be supported starting
+     *             from version 0.7.0. Methods of SerialPort class
+     *             provide better mechanisms for implementing read
+     *             and write timeouts.
      */
     static constexpr short VTIME_DEFAULT = 0;
     

--- a/src/SerialPortConstants.h
+++ b/src/SerialPortConstants.h
@@ -43,22 +43,14 @@ namespace LibSerial
     const int MICROSECONDS_PER_MS  =    1000;
     const int MILLISECONDS_PER_SEC =    1000;
     const int MICROSECONDS_PER_SEC = 1000000;
-        
+
     /**
      * @brief The default character buffer size.
-     * @deprecated VMIN and VTIME will not be supported starting
-     *             from version 0.7.0. Methods of SerialPort class
-     *             provide better mechanisms for implementing read
-     *             and write timeouts.
      */
-    static constexpr short VMIN_DEFAULT = 1;
+    static constexpr short VMIN_DEFAULT = 0;
 
     /**
      * @brief The default character buffer timing.
-     * @deprecated VMIN and VTIME will not be supported starting
-     *             from version 0.7.0. Methods of SerialPort class
-     *             provide better mechanisms for implementing read
-     *             and write timeouts.
      */
     static constexpr short VTIME_DEFAULT = 0;
     

--- a/src/SerialStream.cc
+++ b/src/SerialStream.cc
@@ -84,11 +84,7 @@ SerialStream::Open(const std::string& fileName,
     }
 
     // Open the serial port. 
-    if (0 == mIOBuffer->Open(fileName, openMode))
-    {
-        setstate(badbit);    
-    }
-
+    mIOBuffer->Open(fileName, openMode);
     return;
 }
 

--- a/src/SerialStreamBuf.cc
+++ b/src/SerialStreamBuf.cc
@@ -44,14 +44,14 @@ namespace LibSerial
             /* empty */
         }
 
-        SerialStreamBuf* Open(const string& filename,
+        void Open(const string& filename,
                               ios_base::openmode mode);
 
         /**
          * @brief Closes the serial port. All settings of the serial port will be
          *        lost and no more I/O can be performed on the serial port.
          */
-        SerialStreamBuf* Close();
+        void Close();
 
         /**
          * @brief Determines if the serial port is open for I/O.
@@ -228,18 +228,20 @@ namespace LibSerial
         return next_ch;
     }
 
-    SerialStreamBuf*
+    void
     SerialStreamBuf::Open(const string& filename,
                           ios_base::openmode mode) 
     {
-        return mImpl->Open(filename,
-                           mode);
+        mImpl->Open(filename,
+                    mode);
+        return;
     }
 
-    SerialStreamBuf*
+    void
     SerialStreamBuf::Close() 
     {
-        return mImpl->Close();
+        mImpl->Close();
+        return;
     }
 
     bool
@@ -409,7 +411,7 @@ namespace LibSerial
     }
 
     inline
-    SerialStreamBuf*
+    void
     SerialStreamBuf::Implementation::Open(const string& filename,
                                           ios_base::openmode mode) 
     {
@@ -438,7 +440,7 @@ namespace LibSerial
         } 
         else 
         {
-            return 0;
+            return;
         }
 
         // Try to open the serial port. 
@@ -495,11 +497,11 @@ namespace LibSerial
             throw std::runtime_error(strerror(errno));
         }
 
-        return (SerialStreamBuf*)this;
+        return;
     }
 
     inline
-    SerialStreamBuf*
+    void
     SerialStreamBuf::Implementation::Close() 
     {
         // Throw an exception if the serial port is not open.
@@ -520,15 +522,12 @@ namespace LibSerial
         // to an invalid value.
         if (close(mFileDescriptor) < 0) 
         {
-            // If the close failed then return a null pointer. 
-            return NULL;
+            throw std::runtime_error(strerror(errno));
         } 
 
         // Set the file descriptor to an invalid value, -1. 
         mFileDescriptor = -1;
-        
-        // On success, return "this" as required by the C++ standard.
-        return (SerialStreamBuf*)this;
+        return;
     }
 
     inline

--- a/src/SerialStreamBuf.cc
+++ b/src/SerialStreamBuf.cc
@@ -426,15 +426,15 @@ namespace LibSerial
         
         if (mode == (ios_base::in | ios_base::out))
         {
-            flags = (O_RDWR | O_NOCTTY);
+            flags = (O_RDWR | O_NOCTTY | O_NONBLOCK);
         } 
         else if (mode == ios_base::in)
         {
-            flags = (O_RDONLY | O_NOCTTY);
+            flags = (O_RDONLY | O_NOCTTY | O_NONBLOCK);
         } 
         else if (mode == ios_base::out)
         {
-            flags = (O_WRONLY | O_NOCTTY);
+            flags = (O_WRONLY | O_NOCTTY | O_NONBLOCK);
         } 
         else 
         {

--- a/src/SerialStreamBuf.cc
+++ b/src/SerialStreamBuf.cc
@@ -490,7 +490,7 @@ namespace LibSerial
         }
 
         // Initialize the serial port.
-        if (-1 == InitializeSerialPort())
+        if (InitializeSerialPort() < 0)
         {
             throw std::runtime_error(strerror(errno));
         }
@@ -518,7 +518,7 @@ namespace LibSerial
 
         // Otherwise, close the serial port and set the file descriptor
         // to an invalid value.
-        if (-1 == close(mFileDescriptor)) 
+        if (close(mFileDescriptor) < 0) 
         {
             // If the close failed then return a null pointer. 
             return NULL;
@@ -542,7 +542,7 @@ namespace LibSerial
     int
     SerialStreamBuf::Implementation::InitializeSerialPort()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -551,16 +551,16 @@ namespace LibSerial
         // Use non-blocking mode while configuring the serial port. 
         int flags = fcntl(this->mFileDescriptor, F_GETFL, 0);
         
-        if ( -1 == fcntl( this->mFileDescriptor, 
-                         F_SETFL, 
-                         flags | O_NONBLOCK ) )
+        if (fcntl(this->mFileDescriptor, 
+                  F_SETFL, 
+                  flags | O_NONBLOCK ) < 0)
         {
             return -1;
         }
 
         // Flush out any garbage left behind in the buffers associated
         // with the port from any previous operations. 
-        if ( -1 == tcflush(this->mFileDescriptor, TCIOFLUSH) )
+        if (tcflush(this->mFileDescriptor, TCIOFLUSH) < 0)
         {
             return -1;
         }
@@ -571,9 +571,9 @@ namespace LibSerial
         // Allow all further communications to happen in blocking mode.
         flags = fcntl(this->mFileDescriptor, F_GETFL, 0);
         
-        if ( -1 == fcntl( this->mFileDescriptor, 
-                         F_SETFL, 
-                         flags & ~O_NONBLOCK ) )
+        if (fcntl(this->mFileDescriptor, 
+                  F_SETFL, 
+                  flags & ~O_NONBLOCK) < 0)
         {
             return -1;
         }
@@ -586,7 +586,7 @@ namespace LibSerial
     void 
     SerialStreamBuf::Implementation::SetParametersToDefault()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -664,7 +664,7 @@ namespace LibSerial
 
         // Set the baud rate for both input and output.
         if (cfsetspeed(&port_settings, (speed_t)baudRate) < 0 ||
-            cfsetospeed(&port_settings, (speed_t)baudRate) < 0 )
+            cfsetospeed(&port_settings, (speed_t)baudRate) < 0)
         {
             // If applying the baud rate settings fail, throw an exception.
             throw UnsupportedBaudRate(ERR_MSG_UNSUPPORTED_BAUD_RATE);
@@ -685,7 +685,7 @@ namespace LibSerial
     BaudRate
     SerialStreamBuf::Implementation::GetBaudRate()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -721,7 +721,7 @@ namespace LibSerial
     void
     SerialStreamBuf::Implementation::SetCharacterSize(const CharacterSize& characterSize)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -772,7 +772,7 @@ namespace LibSerial
     CharacterSize
     SerialStreamBuf::Implementation::GetCharacterSize()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -796,7 +796,7 @@ namespace LibSerial
     void
     SerialStreamBuf::Implementation::SetFlowControl(const FlowControl& flowControlType)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -860,7 +860,7 @@ namespace LibSerial
     FlowControl
     SerialStreamBuf::Implementation::GetFlowControl() 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -910,7 +910,7 @@ namespace LibSerial
     void
     SerialStreamBuf::Implementation::SetParity(const Parity& parityType) 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -963,7 +963,7 @@ namespace LibSerial
     Parity
     SerialStreamBuf::Implementation::GetParity() 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1004,7 +1004,7 @@ namespace LibSerial
     void
     SerialStreamBuf::Implementation::SetNumberOfStopBits(const StopBits& numberOfStopBits)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1049,7 +1049,7 @@ namespace LibSerial
     StopBits 
     SerialStreamBuf::Implementation::GetNumberOfStopBits()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1081,7 +1081,7 @@ namespace LibSerial
     void
     SerialStreamBuf::Implementation::SetVMin(const short vmin)
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1119,7 +1119,7 @@ namespace LibSerial
     short 
     SerialStreamBuf::Implementation::GetVMin()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1142,8 +1142,8 @@ namespace LibSerial
     void
     SerialStreamBuf::Implementation::SetVTime(const short vtime)
     {
-        // If we do not have a valid file descriptor then throw an exception.
-        if (-1 == this->mFileDescriptor)
+        // Throw an exception if the serial port is not open.
+        if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
         }
@@ -1180,7 +1180,7 @@ namespace LibSerial
     short 
     SerialStreamBuf::Implementation::GetVTime() 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1204,8 +1204,8 @@ namespace LibSerial
     SerialStreamBuf::Implementation::xsputn(const char_type *s,
                                             streamsize n) 
     {
-        // If we do not have a valid file descriptor then throw an exception.
-        if (-1 == this->mFileDescriptor)
+        // Throw an exception if the serial port is not open.
+        if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
         }
@@ -1220,8 +1220,7 @@ namespace LibSerial
         ssize_t retval = write(mFileDescriptor, s, n);
 
         // If the write failed then return 0. 
-        if (-1 == retval ||
-             0 == retval)
+        if (retval <= 0)
         {
             return 0;
         }
@@ -1234,7 +1233,7 @@ namespace LibSerial
     streamsize
     SerialStreamBuf::Implementation::xsgetn(char_type *s, streamsize n) 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1253,29 +1252,25 @@ namespace LibSerial
         // n-1 character.
         if (mPutbackAvailable)
         {
-            // Put the mPutbackChar at the beginning of the array,
-            // s. Increment retval to indicate that a character has been
-            // placed in s.
-            // 
-            // (Corrected Bug#2364846 by incrementing retval below)
+            // Put the mPutbackChar at the beginning of the array 's'.
+            // Increment retval to indicate that a character has been placed in s.
             s[0] = mPutbackChar; 
             ++retval;
 
             // The putback character is no longer available. 
             mPutbackAvailable = false;
-            //
+
             // If we need to read more than one character, then call read()
             // and try to read n-1 more characters and put them at location
             // starting from &s[1].
-            //
-            if ( n > 1 )
+            if (n > 1)
             {
                 retval = read(mFileDescriptor, &s[1], n-1);
 
                 // If read was successful, then we need to increment retval by
                 // one to indicate that the putback character was prepended to
                 // the array, s. If read failed then leave retval at -1.
-                if ( retval != -1 )
+                if (retval != -1)
                 {
                     retval ++;
                 }
@@ -1284,8 +1279,7 @@ namespace LibSerial
         else
         {
 
-            // If no putback character is available then we try to read n
-            // characters.
+            // If no putback character is available then we try to read n characters.
             retval = read(mFileDescriptor, s, n);
         }
 
@@ -1293,14 +1287,12 @@ namespace LibSerial
         // retval == 0 then we could not read the characters. In either
         // case, we return 0 to indicate that no characters could be read
         // from the serial port.
-        if (-1 == retval ||
-             0 == retval)
+        if (retval <= 0)
         {
             return 0;
         }
 
-        // Return the number of characters actually read from the serial
-        // port.
+        // Return the number of characters actually read from the serial port.
         return retval;
     }
 
@@ -1308,7 +1300,7 @@ namespace LibSerial
     streambuf::int_type
     SerialStreamBuf::Implementation::overflow(const int_type character) 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1327,8 +1319,7 @@ namespace LibSerial
             ssize_t retval = write(mFileDescriptor, &out_ch, 1);
 
             // If the write failed then return eof. 
-            if (-1 == retval ||
-                0 == retval)
+            if (retval <= 0)
             {
                 return traits_type::eof();
             }
@@ -1342,7 +1333,7 @@ namespace LibSerial
     streambuf::int_type
     SerialStreamBuf::Implementation::underflow() 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1373,8 +1364,7 @@ namespace LibSerial
                 mPutbackChar = next_ch;
                 mPutbackAvailable = true;
             }
-            else if (-1 == retval ||
-                      0 == retval)
+            else if (retval <= 0)
             {
                 // If we had a problem reading the character, we return
                 // traits::eof().
@@ -1395,7 +1385,7 @@ namespace LibSerial
     streambuf::int_type
     SerialStreamBuf::Implementation::pbackfail(const int_type character) 
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1428,7 +1418,7 @@ namespace LibSerial
     std::streamsize
     SerialStreamBuf::Implementation::showmanyc()
     {
-        // Make sure that the serial port is open.
+        // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
         {
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
@@ -1446,9 +1436,9 @@ namespace LibSerial
             // Switch to non-blocking read.
             int flags = fcntl(this->mFileDescriptor, F_GETFL, 0);
             
-            if (-1 == fcntl(this->mFileDescriptor, 
-                            F_SETFL, 
-                            flags | O_NONBLOCK))
+            if (fcntl(this->mFileDescriptor, 
+                      F_SETFL, 
+                      flags | O_NONBLOCK) < 0)
             {
                 return -1;
             }
@@ -1466,9 +1456,9 @@ namespace LibSerial
             }
 
             // Switch back to blocking read.
-            if (-1 == fcntl(this->mFileDescriptor,
-                            F_SETFL, 
-                            flags))
+            if (fcntl(this->mFileDescriptor,
+                      F_SETFL, 
+                      flags) < 0)
             {
                 return -1;
             }

--- a/src/SerialStreamBuf.h
+++ b/src/SerialStreamBuf.h
@@ -102,8 +102,8 @@ namespace LibSerial
          * @return Returns <tt>this</tt> on success, a null pointer
          *         otherwise.
          */
-        SerialStreamBuf* Open(const std::string& filename,
-                              std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out);
+        void Open(const std::string& filename,
+                  std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out);
 
         /**
          * @brief If IsOpen() == false, returns a null pointer.
@@ -127,7 +127,7 @@ namespace LibSerial
          * @return Returns <tt>this</tt> on success, a null pointer
          *         otherwise.
          */
-        SerialStreamBuf* Close();
+        void Close();
 
         /**
          * @brief Returns true if a previous call to open() succeeded

--- a/test/LibSerialTest.cpp
+++ b/test/LibSerialTest.cpp
@@ -32,20 +32,27 @@ protected:
     SerialPort serialPort2;
 
     /** @brief The pthread mutex lock to lock data and avoid race conditions. */
-    pthread_mutex_t serialPort1CommunicationsThreadMutex;
-    pthread_mutex_t serialPort2CommunicationsThreadMutex;
+    pthread_mutex_t serialPort1CommunicationThreadMutex;
+    pthread_mutex_t serialPort2CommunicationThreadMutex;
+    pthread_mutex_t serialStream1CommunicationThreadMutex;
+    pthread_mutex_t serialStream2CommunicationThreadMutex;
 
     /** @brief The pthread ID for the communicationsThread. */
-    pthread_t serialPort1CommunicationsThreadID;
-    pthread_t serialPort2CommunicationsThreadID;
+    pthread_t serialPort1CommunicationThreadID;
+    pthread_t serialPort2CommunicationThreadID;
+    pthread_t serialStream1CommunicationThreadID;
+    pthread_t serialStream2CommunicationThreadID;
 
-    bool thread1Running;
-    bool thread2Running;
+    /** @brief A flag to indicate if the thread is currently running. */
+    bool serialPortThread1Running;
+    bool serialPortThread2Running;
+    bool serialStreamThread1Running;
+    bool serialStreamThread2Running;
 
     virtual void SetUp()
     {
-        thread1Running = false;
-        thread2Running = false;
+        serialPortThread1Running = false;
+        serialPortThread2Running = false;
 
         writeString1 = "Quidquid latine dictum sit, altum sonatur. (Whatever is said in Latin sounds profound.)";
         writeString2 = "The universally interesting man is universally interested. - William Dean Howells";
@@ -663,11 +670,21 @@ protected:
         ASSERT_FALSE(serialStream1.IsOpen());
     }
 
+    void testMultiThreadedSerialStreamReadWrite()
+    {
+        engageSerialStreamCommunicationThreads();
+        
+        while(serialStreamThread1Running && serialStreamThread2Running)
+        {
+            usleep(1000);
+        }
+    }
+
     void testMultiThreadedSerialPortReadWrite()
     {
-        engageSerialPortCommunicationsThreads();
+        engageSerialPortCommunicationThreads();
         
-        while(thread1Running && thread2Running)
+        while(serialPortThread1Running && serialPortThread2Running)
         {
             usleep(1000);
         }
@@ -681,7 +698,63 @@ protected:
         return std::chrono::duration_cast<std::chrono::microseconds>(timeNow).count();
     }
 
-    void serialPort1CommunicationsThreadLoop()
+    void serialStream1CommunicationThreadLoop()
+    {
+        serialStream1.Open(TEST_SERIAL_PORT_1);
+        serialStream1.SetBaudRate(BaudRate::BAUD_115200);
+
+        long unsigned int loopStartTimeMicroseconds = 0;
+        long unsigned int timeElapsedMicroSeconds = 0;
+        long unsigned int timeRemainingMicroSeconds = 0;
+
+            while (timeElapsedMicroSeconds < 250000000)
+            {
+                loopStartTimeMicroseconds = getTimeInMicroSeconds();
+
+                serialStream1 << writeString1 << std::endl;
+                getline(serialStream1, readString2);
+                ASSERT_EQ(readString2, writeString2);
+
+                timeRemainingMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
+
+                usleep(timeRemainingMicroSeconds);
+
+                timeElapsedMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
+            }
+
+        serialStream1.Close();
+        serialStreamThread1Running = false;
+    }
+
+    void serialStream2CommunicationThreadLoop()
+    {
+        serialStream2.Open(TEST_SERIAL_PORT_1);
+        serialStream2.SetBaudRate(BaudRate::BAUD_115200);
+
+        long unsigned int loopStartTimeMicroseconds = 0;
+        long unsigned int timeElapsedMicroSeconds = 0;
+        long unsigned int timeRemainingMicroSeconds = 0;
+
+            while (timeElapsedMicroSeconds < 250000000)
+            {
+                loopStartTimeMicroseconds = getTimeInMicroSeconds();
+
+                serialStream2 << writeString2 << std::endl;
+                getline(serialStream2, readString1);
+                ASSERT_EQ(readString1, writeString1);
+
+                timeRemainingMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
+
+                usleep(timeRemainingMicroSeconds);
+
+                timeElapsedMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
+            }
+
+        serialStream2.Close();
+        serialStreamThread1Running = false;
+    }
+
+    void serialPort1CommunicationThreadLoop()
     {
         serialPort1.Open();
         serialPort1.SetBaudRate(BaudRate::BAUD_115200);
@@ -699,8 +772,8 @@ protected:
                 serialPort1.Write(writeString1 + '\n');
                 tcdrain(serialPort1.GetFileDescriptor());
 
-                serialPort1.ReadLine(readString1, '\n', timeOutMilliseconds);
-                // ASSERT_EQ(readString, writeString + '\n');
+                serialPort1.ReadLine(readString2, '\n', timeOutMilliseconds);
+                ASSERT_EQ(readString2, writeString2 + '\n');
 
                 timeRemainingMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
 
@@ -710,10 +783,10 @@ protected:
             }
 
         serialPort1.Close();
-        thread1Running = false;
+        serialPortThread1Running = false;
     }
 
-    void serialPort2CommunicationsThreadLoop()
+    void serialPort2CommunicationThreadLoop()
     {
         serialPort2.Open();
         serialPort2.SetBaudRate(BaudRate::BAUD_115200);
@@ -731,8 +804,8 @@ protected:
             serialPort2.Write(writeString2 + '\n');
             tcdrain(serialPort2.GetFileDescriptor());
 
-            serialPort2.ReadLine(readString2, '\n', timeOutMilliseconds);
-            // ASSERT_EQ(readString, writeString + '\n');
+            serialPort2.ReadLine(readString1, '\n', timeOutMilliseconds);
+            ASSERT_EQ(readString1, writeString1 + '\n');
 
             timeRemainingMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
 
@@ -742,33 +815,60 @@ protected:
         }
 
         serialPort2.Close();
-        thread2Running = false;
+        serialPortThread2Running = false;
     }
 
-    void engageSerialPortCommunicationsThreads()
+    void engageSerialPortCommunicationThreads()
     {
-        pthread_mutex_init(&serialPort1CommunicationsThreadMutex, NULL);
-        pthread_create(&serialPort1CommunicationsThreadID, NULL, &startSerialPort1CommunicationsThread, this);
+        pthread_mutex_init(&serialPort1CommunicationThreadMutex, NULL);
+        pthread_create(&serialPort1CommunicationThreadID, NULL, &startSerialPort1CommunicationThread, this);
 
-        pthread_mutex_init(&serialPort2CommunicationsThreadMutex, NULL);
-        pthread_create(&serialPort2CommunicationsThreadID, NULL, &startSerialPort2CommunicationsThread, this);
+        pthread_mutex_init(&serialPort2CommunicationThreadMutex, NULL);
+        pthread_create(&serialPort2CommunicationThreadID, NULL, &startSerialPort2CommunicationThread, this);
 
-        thread1Running = true;
-        thread2Running = true;
+        serialPortThread1Running = true;
+        serialPortThread2Running = true;
         return;
     }
 
-    static void* startSerialPort1CommunicationsThread(void *args)
+    void engageSerialStreamCommunicationThreads()
+    {
+        pthread_mutex_init(&serialStream1CommunicationThreadMutex, NULL);
+        pthread_create(&serialStream1CommunicationThreadID, NULL, &startSerialStream1CommunicationThread, this);
+
+        pthread_mutex_init(&serialStream2CommunicationThreadMutex, NULL);
+        pthread_create(&serialStream2CommunicationThreadID, NULL, &startSerialStream2CommunicationThread, this);
+
+        serialStreamThread1Running = true;
+        serialStreamThread2Running = true;
+        return;
+    }
+
+    static void* startSerialPort1CommunicationThread(void *args)
     {
         LibSerialTest* libSerialTest  = (LibSerialTest*) args;
-        libSerialTest->serialPort1CommunicationsThreadLoop();
+        libSerialTest->serialPort1CommunicationThreadLoop();
         return NULL;
     }
 
-    static void* startSerialPort2CommunicationsThread(void *args)
+    static void* startSerialPort2CommunicationThread(void *args)
     {
         LibSerialTest* libSerialTest  = (LibSerialTest*) args;
-        libSerialTest->serialPort2CommunicationsThreadLoop();
+        libSerialTest->serialPort2CommunicationThreadLoop();
+        return NULL;
+    }
+
+    static void* startSerialStream1CommunicationThread(void *args)
+    {
+        LibSerialTest* libSerialTest  = (LibSerialTest*) args;
+        libSerialTest->serialStream1CommunicationThreadLoop();
+        return NULL;
+    }
+
+    static void* startSerialStream2CommunicationThread(void *args)
+    {
+        LibSerialTest* libSerialTest  = (LibSerialTest*) args;
+        libSerialTest->serialStream2CommunicationThreadLoop();
         return NULL;
     }
 
@@ -1046,10 +1146,16 @@ TEST_F(LibSerialTest, testSerialStreamToSerialPortReadWrite)
 }
 
 
-//----------------------- Multiple Thread Unit Test -------------------------//
+//----------------------- Multiple Thread Unit Tests ------------------------//
 
 TEST_F(LibSerialTest, testMultiThreadedSerialPortReadWrite)
 {
-    SCOPED_TRACE("Test Multi-Threaded Serial Communications.");
+    SCOPED_TRACE("Test Multi-Threaded Serial Port Communication.");
     testMultiThreadedSerialPortReadWrite();
+}
+
+TEST_F(LibSerialTest, testMultiThreadedSerialStreamReadWrite)
+{
+    SCOPED_TRACE("Test Multi-Threaded Serial Stream Communication.");
+    testMultiThreadedSerialStreamReadWrite();
 }

--- a/test/LibSerialTest.cpp
+++ b/test/LibSerialTest.cpp
@@ -760,27 +760,22 @@ protected:
         serialPort1.SetBaudRate(BaudRate::BAUD_115200);
         tcflush(serialPort1.GetFileDescriptor(), TCIOFLUSH);
 
-        long unsigned int loopStartTimeMicroseconds = 0;
+        long unsigned int loopStartTimeMicroseconds = getTimeInMicroSeconds();
         long unsigned int timeElapsedMicroSeconds = 0;
-        long unsigned int timeRemainingMicroSeconds = 0;
         long unsigned int timeOutMilliseconds = 25;
 
-            while (timeElapsedMicroSeconds < 250000000)
-            {
-                loopStartTimeMicroseconds = getTimeInMicroSeconds();
+        loopStartTimeMicroseconds = getTimeInMicroSeconds();
 
-                serialPort1.Write(writeString1 + '\n');
-                tcdrain(serialPort1.GetFileDescriptor());
+        while (timeElapsedMicroSeconds < 100000000)
+        {
+            serialPort1.Write(writeString1 + '\n');
+            tcdrain(serialPort1.GetFileDescriptor());
 
-                serialPort1.ReadLine(readString2, '\n', timeOutMilliseconds);
-                ASSERT_EQ(readString2, writeString2 + '\n');
+            serialPort1.ReadLine(readString2, '\n', timeOutMilliseconds);
+            ASSERT_EQ(readString2, writeString2 + '\n');
 
-                timeRemainingMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
-
-                usleep(timeRemainingMicroSeconds);
-
-                timeElapsedMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
-            }
+            timeElapsedMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
+        }
 
         serialPort1.Close();
         serialPort1ThreadRunning = false;
@@ -792,24 +787,19 @@ protected:
         serialPort2.SetBaudRate(BaudRate::BAUD_115200);
         tcflush(serialPort1.GetFileDescriptor(), TCIOFLUSH);
 
-        long unsigned int loopStartTimeMicroseconds = 0;
+        long unsigned int loopStartTimeMicroseconds = getTimeInMicroSeconds();
         long unsigned int timeElapsedMicroSeconds = 0;
-        long unsigned int timeRemainingMicroSeconds = 0;
-        long unsigned int timeOutMilliseconds = 250;
+        long unsigned int timeOutMilliseconds = 25;
 
-        while (timeElapsedMicroSeconds < 250000000)
+        loopStartTimeMicroseconds = getTimeInMicroSeconds();
+
+        while (timeElapsedMicroSeconds < 100000000)
         {
-            loopStartTimeMicroseconds = getTimeInMicroSeconds();
-
             serialPort2.Write(writeString2 + '\n');
             tcdrain(serialPort2.GetFileDescriptor());
 
             serialPort2.ReadLine(readString1, '\n', timeOutMilliseconds);
             ASSERT_EQ(readString1, writeString1 + '\n');
-
-            timeRemainingMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
-
-            usleep(timeRemainingMicroSeconds);
 
             timeElapsedMicroSeconds = getTimeInMicroSeconds() - loopStartTimeMicroseconds;
         }

--- a/test/LibSerialTest.cpp
+++ b/test/LibSerialTest.cpp
@@ -44,15 +44,15 @@ protected:
     pthread_t serialStream2CommunicationThreadID;
 
     /** @brief A flag to indicate if the thread is currently running. */
-    bool serialPortThread1Running;
-    bool serialPortThread2Running;
-    bool serialStreamThread1Running;
-    bool serialStreamThread2Running;
+    bool serialPort1ThreadRunning;
+    bool serialPort2ThreadRunning;
+    bool serialStream1ThreadRunning;
+    bool serialStream2ThreadRunning;
 
     virtual void SetUp()
     {
-        serialPortThread1Running = false;
-        serialPortThread2Running = false;
+        serialPort1ThreadRunning = false;
+        serialPort2ThreadRunning = false;
 
         writeString1 = "Quidquid latine dictum sit, altum sonatur. (Whatever is said in Latin sounds profound.)";
         writeString2 = "The universally interesting man is universally interested. - William Dean Howells";
@@ -674,7 +674,7 @@ protected:
     {
         engageSerialStreamCommunicationThreads();
         
-        while(serialStreamThread1Running && serialStreamThread2Running)
+        while(serialStream1ThreadRunning && serialStream2ThreadRunning)
         {
             usleep(1000);
         }
@@ -684,7 +684,7 @@ protected:
     {
         engageSerialPortCommunicationThreads();
         
-        while(serialPortThread1Running && serialPortThread2Running)
+        while(serialPort1ThreadRunning && serialPort2ThreadRunning)
         {
             usleep(1000);
         }
@@ -723,7 +723,7 @@ protected:
             }
 
         serialStream1.Close();
-        serialStreamThread1Running = false;
+        serialStream1ThreadRunning = false;
     }
 
     void serialStream2CommunicationThreadLoop()
@@ -751,7 +751,7 @@ protected:
             }
 
         serialStream2.Close();
-        serialStreamThread1Running = false;
+        serialStream2ThreadRunning = false;
     }
 
     void serialPort1CommunicationThreadLoop()
@@ -783,7 +783,7 @@ protected:
             }
 
         serialPort1.Close();
-        serialPortThread1Running = false;
+        serialPort1ThreadRunning = false;
     }
 
     void serialPort2CommunicationThreadLoop()
@@ -815,7 +815,7 @@ protected:
         }
 
         serialPort2.Close();
-        serialPortThread2Running = false;
+        serialPort2ThreadRunning = false;
     }
 
     void engageSerialPortCommunicationThreads()
@@ -826,8 +826,8 @@ protected:
         pthread_mutex_init(&serialPort2CommunicationThreadMutex, NULL);
         pthread_create(&serialPort2CommunicationThreadID, NULL, &startSerialPort2CommunicationThread, this);
 
-        serialPortThread1Running = true;
-        serialPortThread2Running = true;
+        serialPort1ThreadRunning = true;
+        serialPort2ThreadRunning = true;
         return;
     }
 
@@ -839,8 +839,8 @@ protected:
         pthread_mutex_init(&serialStream2CommunicationThreadMutex, NULL);
         pthread_create(&serialStream2CommunicationThreadID, NULL, &startSerialStream2CommunicationThread, this);
 
-        serialStreamThread1Running = true;
-        serialStreamThread2Running = true;
+        serialStream1ThreadRunning = true;
+        serialStream2ThreadRunning = true;
         return;
     }
 


### PR DESCRIPTION
Hi CrayzeeWulf,

I've added a unit test for threaded serial stream communications to mirror the serial port threaded communications test and renamed a mutex lock variable to match the buffer it is locking in this pull request.

It appears that both the serial port and serial stream communications suffer from a similar issue when used in a threaded application, so I am continuing to investigate and learn what I can.

Please let me know if you have any questions on this PR!

-Mark