### PR TITLE
Added #include <cerrno> and #include <stdlib.h> to fix Build Issues #89

### DIFF
--- a/src/PosixSignalDispatcher.cpp
+++ b/src/PosixSignalDispatcher.cpp
@@ -20,6 +20,7 @@
 #include "PosixSignalDispatcher.h"
 #include "PosixSignalHandler.h"
 
+#include <cerrno>
 #include <cstring>
 #include <map>
 #include <sstream>

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -23,11 +23,13 @@
 #include "PosixSignalDispatcher.h"
 #include "PosixSignalHandler.h"
 
+#include <cerrno>
 #include <cstring>
 #include <iostream>
 #include <fcntl.h>
 #include <queue>
 #include <signal.h>
+#include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <unistd.h>


### PR DESCRIPTION
This PR adds `#include <stdlib.h>` to SerialPort.cpp and  `#include <cerrno>` to SerialPort.cpp and PosixSignalDispatcher.cpp to fix the compiler errors reported in Build Issues #89.

-Mark