### PR TITLE
Fixes for Build Issues #89

### DIFF
--- a/doxygen.conf.in
+++ b/doxygen.conf.in
@@ -791,7 +791,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = docs examples sip src test 
+INPUT                  = docs examples src 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -25,13 +25,14 @@
 #include <cstring>
 #include <fcntl.h>
 #include <linux/serial.h>
+#include <stdlib.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
 namespace LibSerial 
 {
     /**
-     * @brief The SerialPort Implementation Class.
+     * @brief SerialPort::Implementation is the SerialPort implementation class.
      */
     class SerialPort::Implementation
     {
@@ -1081,7 +1082,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1120,7 +1121,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1156,7 +1157,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1208,7 +1209,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1239,7 +1240,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1296,7 +1297,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1346,7 +1347,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1399,7 +1400,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1440,7 +1441,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1485,7 +1486,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1522,7 +1523,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1555,7 +1556,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1583,7 +1584,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1616,7 +1617,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1931,7 +1932,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1966,7 +1967,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -2000,7 +2001,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -2033,7 +2034,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -2067,7 +2068,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -2142,6 +2143,7 @@ namespace LibSerial
             // Obtain the current time.
             current_time = std::chrono::high_resolution_clock::now().time_since_epoch();
 
+            // Calculate the time delta.
             elapsed_time = current_time - entry_time;
 
             // Calculate the elapsed number of milliseconds.
@@ -2216,6 +2218,7 @@ namespace LibSerial
             // Obtain the current time.
             current_time = std::chrono::high_resolution_clock::now().time_since_epoch();
 
+            // Calculate the time delta.
             elapsed_time = current_time - entry_time;
 
             // Calculate the elapsed number of milliseconds.
@@ -2285,6 +2288,7 @@ namespace LibSerial
                 // Obtain the current time.
                 current_time = std::chrono::high_resolution_clock::now().time_since_epoch();
 
+                // Calculate the time delta.
                 elapsed_time = current_time - entry_time;
 
                 // Calculate the elapsed number of milliseconds.
@@ -2358,6 +2362,7 @@ namespace LibSerial
                 // Obtain the current time.
                 current_time = std::chrono::high_resolution_clock::now().time_since_epoch();
 
+                // Calculate the time delta.
                 elapsed_time = current_time - entry_time;
 
                 // Calculate the elapsed number of milliseconds.
@@ -2451,6 +2456,7 @@ namespace LibSerial
             // Obtain the current time.
             current_time = std::chrono::high_resolution_clock::now().time_since_epoch();
 
+            // Calculate the time delta.
             elapsed_time = current_time - entry_time;
 
             // Calculate the elapsed number of milliseconds.

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -28,6 +28,15 @@
 
 namespace LibSerial 
 {
+    /**
+     * @brief SerialPort allows an object oriented approach to serial port
+     *        communication.  A serial port object can be created to
+     *        allow opening the port with specified modes and settings.
+     *        The SerialPort class also provides Get/Set methods to
+     *        access the most commonly utilized parameters associated
+     *        with serial port communication.
+     *
+     */
     class SerialPort
     {
     public:

--- a/src/SerialPortConstants.h
+++ b/src/SerialPortConstants.h
@@ -22,6 +22,7 @@
 #ifndef SERIALPORTCONSTANTS_H
 #define SERIALPORTCONSTANTS_H
 
+#include <cerrno>
 #include <iostream>
 #include <limits>
 #include <termios.h>

--- a/src/SerialStream.h
+++ b/src/SerialStream.h
@@ -28,10 +28,10 @@
 namespace LibSerial 
 {
     /**
-     * @brief A stream class for accessing serial ports on POSIX operating
-     *        systems. A lot of the functionality of this class has been
-     *        obtained by looking at the code of libserial package by Linas
-     *        Vepstas, (linas@linas.org) and the excellent document on
+     * @brief SerialStream is a stream class for accessing serial ports on
+     *        POSIX operating systems. A lot of the functionality of this class
+     *        has been obtained by looking at the code of libserial package by
+     *        Linas Vepstas, (linas@linas.org) and the excellent document on
      *        serial programming by Michael R. Sweet. This document can be
      *        found at
      *        <ahref="http://www.easysw.com/~mike/serial/serial.html">

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -30,7 +30,7 @@
 namespace LibSerial
 {
     /**
-     * @brief The SerialStreamBuf Implementation Class.
+     * @brief SerialStreamBuf::Implementation is the SerialStreamBuf implementation class.
      */
     class SerialStreamBuf::Implementation
     {
@@ -947,7 +947,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -986,7 +986,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1022,7 +1022,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1074,7 +1074,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1105,7 +1105,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1162,7 +1162,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1212,7 +1212,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1265,7 +1265,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1306,7 +1306,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1351,7 +1351,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1388,7 +1388,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1421,7 +1421,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1449,7 +1449,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1482,7 +1482,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1797,7 +1797,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1832,7 +1832,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1866,7 +1866,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1899,7 +1899,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)
@@ -1933,7 +1933,7 @@ namespace LibSerial
 
         // Get the current serial port settings.
         termios port_settings;
-        memset(&port_settings, 0, sizeof(port_settings));
+        std::memset(&port_settings, 0, sizeof(port_settings));
         
         if (tcgetattr(this->mFileDescriptor,
                       &port_settings) < 0)

--- a/src/SerialStreamBuf.h
+++ b/src/SerialStreamBuf.h
@@ -30,16 +30,15 @@
 namespace LibSerial
 {
     /**
-     * @brief This is the streambuf subclass used by SerialStream. This
-     *        subclass takes care of opening the serial port file in the
-     *        required modes and providing the corresponding file
-     *        descriptor to SerialStream so that various parameters
-     *        associated with the serial port can be set. Several
-     *        features of this streambuf class resemble those of
-     *        std::filebuf, however this class it not made a subclass of
-     *        filebuf because we need access to the file descriptor
-     *        associated with the serial port and the standard filebuf
-     *        does not provide access to it.
+     * @brief SerialStreamBuf is the streambuf subclass used by SerialStream.
+     *        This subclass takes care of opening the serial port file in the
+     *        required modes and providing the corresponding file descriptor
+     *        to SerialStream so that various parameters associated with the
+     *        serial port can be set. Several features of this streambuf class
+     *        resemble those of std::filebuf, however this class it not made a
+     *        subclass of filebuf because we need access to the file descriptor
+     *        associated with the serial port and the standard filebuf does not
+     *        provide access to it.
      *
      *        At present, this class uses unbuffered I/O and all calls
      *        to setbuf() will be ignored.


### PR DESCRIPTION
Updates to documentation, added explicit std:: scope resolution operators to memset() calls, and added #includes to address compiler errors on virtual machines.

-Mark