### PR TITLE
Updated SerialPort Read() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,16 @@ Then run `configure`:
 ./configure 
 ```
 
+You can specify an installation directory different from the default, (/usr/local/), by adding the --prefix= command to the configure command.  For example:
+```
+./configure --prefix=/usr/include/
+```
+
 Once you have the `configure` script, run the following commands:
 
 ```
 make
-make install
+sudo make install
 ```
 
 ----

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then run `configure`:
 ./configure 
 ```
 
-You can specify an installation directory different from the default, (/usr/local/), by adding the --prefix= command to the configure command.  For example:
+You can specify an installation directory different from the default, (/usr/local/), by adding `--prefix=/installation/directory/path/` to the configure command.  For example:
 ```
 ./configure --prefix=/usr/include/
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make -f Makefile.dist
 ```
 
 ----
-You can skip the configure step if you are using a release package which already contains the `configure` script, otherwise:
+Then run `configure`:
 
 ```
 ./configure 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can specify an installation directory different from the default, (/usr/loca
 ./configure --prefix=/usr/include/
 ```
 
-Once you have the `configure` script, run the following commands:
+Once you have the `configure` script, you can build the library with `make` and install with `make install`:
 
 ```
 make

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you simply want to use LibSerial and you already utilize a Debian Linux distr
 sudo apt install libserial-dev
 ```
 
-Otherwise, if you are developing and would like to make use of the latest development, yhou will likely need to install a few packages to build LibSerial:
+Otherwise, if you are a developer and would like to make use of the latest code, you will need to have a few packages installed to build LibSerial:
 	a recent g++ release, (anything after gcc-3.2 should work), the python sip library, the boost unit test library, and Google Test (gtest).  For Debian users:
 
 ```
@@ -45,7 +45,7 @@ sudo make install
 ```
 
 ----
-If you are a developer interested in utilizing the unit tests, ensure serial port names are appropriate for your hardware configuration in the UnitTests.cpp file:
+If you are interested in running the unit tests, ensure serial port names are appropriate for your hardware configuration in the UnitTests.cpp file:
 
 ```
 #define TEST_SERIAL_PORT_1 "/dev/ttyUSB0"
@@ -74,4 +74,4 @@ Alternatively, unit test executables built using the compile script can be run f
 Complete documentation is available [here](http://libserial.readthedocs.io/en/latest/index.html).
 
 ----
-(You can let people know that this Repository was useful to you by clicking the "Star" in the upper right of the repository home page!)
+(You can let people know that this Repository was useful to you by clicking the "star" in the upper right of the repository home page!)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 ----
 LibSerial provides a convenient, object oriented approach to accessing serial ports on POSIX systems.
 
-You will need a recent g++ release, (anything after gcc-3.2 should work), to compile libserial, and you will also need to install Google Test (gtest) and the boost unit test library.  For Debian users:
+You will likely need to install a few packages to build LibSerial: a recent g++ release, (anything after gcc-3.2 should work), the python sip library, the boost unit test library, and Google Test (gtest).  For Debian users:
 
 ```
-sudo apt install libgtest-dev libboost-dev
+sudo update
+sudo apt install build-essential libgtest-dev libboost-dev python-sip-dev
 ```
 ----
 If you get the source code from github and would like to install the library, you will need to generate the configure script first:

--- a/README.md
+++ b/README.md
@@ -17,10 +17,15 @@ make -f Makefile.dist
 ```
 
 ----
-You can skip this step if you are using a release package (which already contains the `configure` script). Once you have the `configure` script, run the following commands:
+You can skip the configure step if you are using a release package which already contains the `configure` script, otherwise:
 
 ```
 ./configure 
+```
+
+Once you have the `configure` script, run the following commands:
+
+```
 make
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # Libserial
 
 ----
-LibSerial provides a convenient, object oriented approach to accessing serial ports on POSIX systems.
+Thanks for checking out LibSerial!  LibSerial provides a convenient, object oriented approach to accessing serial ports on POSIX systems.
 
-You will likely need to install a few packages to build LibSerial: a recent g++ release, (anything after gcc-3.2 should work), the python sip library, the boost unit test library, and Google Test (gtest).  For Debian users:
+After you get to know LibSerial a bit, if you find that you have ideas for improvement, please be sure to let us know!
+
+If you simply want to use LibSerial and you already utilize a Debian Linux distribution, use apt to install the current release package:
+
+```
+sudo apt install libserial-dev
+```
+
+Otherwise, if you are developing and would like to make use of the latest development, yhou will likely need to install a few packages to build LibSerial:
+	a recent g++ release, (anything after gcc-3.2 should work), the python sip library, the boost unit test library, and Google Test (gtest).  For Debian users:
 
 ```
 sudo update

--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 mkdir -p build
 cd build
 cmake ..

--- a/examples/main_page_example.cpp
+++ b/examples/main_page_example.cpp
@@ -34,7 +34,7 @@ int main()
    try
    {
       // Read a character.
-      serial_port.Read(read_byte_1, 1);
+      serial_port.Read(&read_byte_1, 1);
       serial_stream >> read_byte_2;
    }
    catch (ReadTimeout)

--- a/examples/main_page_example.cpp
+++ b/examples/main_page_example.cpp
@@ -28,13 +28,15 @@ int main()
    char read_byte_2 = 'B';
 
    // Write a character.
-   serial_port.Write(&write_byte_1, 1);
+   serial_port.WriteByte(write_byte_1);
    serial_stream << write_byte_2;
+
+   size_t timeout_milliseconds = 5;
 
    try
    {
       // Read a character.
-      serial_port.Read(&read_byte_1, 1);
+      serial_port.ReadByte(read_byte_1, timeout_milliseconds);
       serial_stream >> read_byte_2;
    }
    catch (ReadTimeout)

--- a/examples/serial_port_read.cpp
+++ b/examples/serial_port_read.cpp
@@ -4,9 +4,10 @@
 
 #include <SerialPort.h>
 
+#include <cstring>
+#include <cstdlib>
 #include <iostream>
 #include <unistd.h>
-#include <cstdlib>
 
 using namespace LibSerial;
 
@@ -44,54 +45,48 @@ int main()
     }
 
     // Timeout value in milliseconds to wait for data being read.
-    size_t ms_timeout = 25;
+    size_t ms_timeout = 250;
 
     // Char variable to store data coming from the serial port.
     char data_byte;
 
-    // Char array pointer to store data coming from the serial port.
-    char* readBuffer = new char[256];
-
-    // Read a single byte at a time from serial port and output to the terminal.
-    while(serial_port.IsDataAvailable()) 
+    // Read one byte from the serial port and print it to the terminal.
+    try
     {
-        try
-        {
-            // Read a single byte of data from the serial port.
-            serial_port.ReadByte(data_byte, ms_timeout);
+        // Read a single byte of data from the serial port.
+        serial_port.ReadByte(data_byte, ms_timeout);
 
-            // Show the user what is being read from the serial port.
-            std::cout << data_byte;
-        }
-        catch (ReadTimeout)
-        {
-            std::cerr << "The ReadByte() call has timed out." << std::endl;
-        }
-
-        // Wait a brief period for more data to arrive.
-        usleep(1000);
+        // Show the user what is being read from the serial port.
+        std::cout << data_byte << std::flush;
+    }
+    catch (ReadTimeout)
+    {
+        std::cerr << "\nThe ReadByte() call has timed out." << std::endl;
     }
 
-    // Read the remaining data until the time remaining expires.
-    while(serial_port.IsDataAvailable()) 
+    // Wait a brief period for more data to arrive.
+    usleep(1000);
+
+    // Size of the char array.
+    const size_t array_size = 128;
+
+    // Char array to store data coming from the serial port.
+    char read_buffer[array_size];
+
+    // Clear the array contents.
+    std::memset(read_buffer, 0, array_size);
+
+    try
     {
-        try
-        {
-            // Read as many bytes as are available during the timeout period.
-            serial_port.Read(readBuffer, 0, ms_timeout);
-
-        }
-        catch (ReadTimeout)
-        {
-            std::cerr << "The ReadByte() call has timed out waiting for more data." << std::endl;
-        }
-
-        // Show the user what was read from the serial port.
-        for (size_t i = 0; i < sizeof(readBuffer); i++)
-        {
-            std::cout << readBuffer + i;
-        }
+        // Read as many bytes as are available during the timeout period.
+        serial_port.Read(read_buffer, 0, ms_timeout);
     }
+    catch (ReadTimeout)
+    {
+        std::cerr << "\nThe Read() call has timed out waiting for more data." << std::endl;
+    }
+
+    std::cout << read_buffer << std::flush;
 
     // Successful program completion.
     std::cout << "Done." << std::endl;

--- a/examples/serial_port_read.cpp
+++ b/examples/serial_port_read.cpp
@@ -46,10 +46,13 @@ int main()
     // Timeout value in milliseconds to wait for data being read.
     size_t ms_timeout = 25;
 
-    // Variable to store data coming from the serial port.
+    // Char variable to store data coming from the serial port.
     char data_byte;
 
-    // Keep reading data from serial port and print it to the screen.
+    // Char array pointer to store data coming from the serial port.
+    char* readBuffer = new char[256];
+
+    // Read a single byte at a time from serial port and output to the terminal.
     while(serial_port.IsDataAvailable()) 
     {
         try
@@ -67,6 +70,27 @@ int main()
 
         // Wait a brief period for more data to arrive.
         usleep(1000);
+    }
+
+    // Read the remaining data until the time remaining expires.
+    while(serial_port.IsDataAvailable()) 
+    {
+        try
+        {
+            // Read as many bytes as are available during the timeout period.
+            serial_port.Read(readBuffer, 0, ms_timeout);
+
+        }
+        catch (ReadTimeout)
+        {
+            std::cerr << "The ReadByte() call has timed out waiting for more data." << std::endl;
+        }
+
+        // Show the user what was read from the serial port.
+        for (size_t i = 0; i < sizeof(readBuffer); i++)
+        {
+            std::cout << readBuffer + i;
+        }
     }
 
     // Successful program completion.

--- a/examples/serial_port_read.cpp
+++ b/examples/serial_port_read.cpp
@@ -81,7 +81,7 @@ int main()
             std::cout << read_buffer.at(i) << std::flush;
         }
 
-        std::cerr << "\nThe Read() call timed out waiting for additional data." << std::endl;
+        std::cerr << "The Read() call timed out waiting for additional data." << std::endl;
     }
 
     // Successful program completion.

--- a/examples/serial_port_read.cpp
+++ b/examples/serial_port_read.cpp
@@ -67,14 +67,7 @@ int main()
     // Wait a brief period for more data to arrive.
     usleep(1000);
 
-    // Size of the char array.
-    const size_t array_size = 128;
-
-    // Char array to store data coming from the serial port.
-    char read_buffer[array_size];
-
-    // Clear the array contents.
-    std::memset(read_buffer, 0, array_size);
+    DataBuffer read_buffer;
 
     try
     {
@@ -83,12 +76,15 @@ int main()
     }
     catch (ReadTimeout)
     {
-        std::cerr << "\nThe Read() call has timed out waiting for more data." << std::endl;
+        for (size_t i = 0; i < read_buffer.size(); i++)
+        {
+            std::cout << read_buffer.at(i) << std::flush;
+        }
+
+        std::cerr << "\nThe Read() call timed out waiting for additional data." << std::endl;
     }
 
-    std::cout << read_buffer << std::flush;
-
     // Successful program completion.
-    std::cout << "Done." << std::endl;
+    std::cout << "The example program successfully completed!" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/examples/serial_port_read_write.cpp
+++ b/examples/serial_port_read_write.cpp
@@ -61,8 +61,11 @@ int main()
     char read_byte_2  = ' ';
 
     // Variables to store outgoing and incoming data.
-    std::string write_string_1 = "\"Do what you can, with what you have, where you are.\" - Theodore Roosevelt";
-    std::string write_string_2 = "\"Simplicity is prerequisite for reliability.\" - Edsger W. Dijkstra";
+    std::string write_string_1 =
+        "\"Do what you can, with what you have, where you are.\" - Theodore Roosevelt";
+    
+    std::string write_string_2 =
+        "\"Simplicity is prerequisite for reliability.\" - Edsger W. Dijkstra";
 
     std::string read_string_1 = "";
     std::string read_string_2 = "";
@@ -74,6 +77,10 @@ int main()
     // Write a single byte of data to the serial ports.
     serial_port_1.WriteByte(write_byte_1);
     serial_port_2.WriteByte(write_byte_2);
+
+    // Wait until the data has actually been transmitted.
+    serial_port_1.DrainWriteBuffer();
+    serial_port_2.DrainWriteBuffer();
 
     // Specify a read timeout value in milliseconds.
     size_t timeout_milliseconds = 25;
@@ -105,6 +112,10 @@ int main()
     // Write a string to each serial port.
     serial_port_1.Write(write_string_1);
     serial_port_2.Write(write_string_2);
+
+    // Wait until the data has actually been transmitted.
+    serial_port_1.DrainWriteBuffer();
+    serial_port_2.DrainWriteBuffer();
 
     try
     {

--- a/examples/serial_port_read_write.cpp
+++ b/examples/serial_port_read_write.cpp
@@ -164,6 +164,7 @@ int main()
     serial_port_1.Close();
     serial_port_2.Close();
 
+    // Successful program completion.
     std::cout << "The example program successfully completed!" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/examples/serial_port_read_write.cpp
+++ b/examples/serial_port_read_write.cpp
@@ -130,9 +130,13 @@ int main()
     std::string user_input;
     user_input.clear();
     
+    // Print to the terminal what will take place next.
+    std::cout << "Using Write() and ReadLine() to write a string and "
+              << "read a line of data:" << std::endl << std::endl;
+
     // Prompt the user for input.
-    std::cout << "Type something you would like to send over serial,"
-              << " (enter \"Q\" or \"q\" to quit): " << std::flush;
+    std::cout << "Enter something you would like to send over "
+              << "serial, (enter \"Q\" or \"q\" to quit): " << std::flush;
     
     while(true)
     {
@@ -144,10 +148,6 @@ int main()
         {
             break;
         }
-
-        // Print to the terminal what will take place next.
-        std::cout << "Using Write() and ReadLine() to write a string and "
-                  << "read a line of data:" << std::endl;
 
         // Write the user input to the serial port.
         serial_port_1.Write(user_input + "\n");

--- a/examples/serial_port_write.cpp
+++ b/examples/serial_port_write.cpp
@@ -74,6 +74,9 @@ int main(int argc, char** argv)
         // Write the data to the serial port.
         serial_port.WriteByte(data_byte);
 
+        // Wait until the data has actually been transmitted.
+        serial_port.DrainWriteBuffer();
+
         // Print to the terminal what is being written to the serial port.
         std::cout << data_byte;
     }

--- a/examples/serial_port_write.cpp
+++ b/examples/serial_port_write.cpp
@@ -79,6 +79,6 @@ int main(int argc, char** argv)
     }
 
     // Successful program completion.
-    std::cout << std::endl << "Done." << std::endl;
+    std::cout << "The example program successfully completed!" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/examples/serial_stream_read_write.cpp
+++ b/examples/serial_stream_read_write.cpp
@@ -69,6 +69,10 @@ int main()
     serial_stream_1.write(write_string_1.c_str(), write_string_1.size());
     serial_stream_2.write(write_string_2.c_str(), write_string_2.size());
 
+    // Wait until the data has actually been transmitted.
+    serial_stream_1.DrainWriteBuffer();
+    serial_stream_2.DrainWriteBuffer();
+
     // Char arrays to store incoming data.
     char* read_array_1 = new char[write_string_2.size()];
     char* read_array_2 = new char[write_string_1.size()];
@@ -93,6 +97,10 @@ int main()
     // Write a line at each serial port.
     serial_stream_1 << write_string_1 << std::endl;
     serial_stream_2 << write_string_2 << std::endl;
+
+    // Wait until the data has actually been transmitted.
+    serial_stream_1.DrainWriteBuffer();
+    serial_stream_2.DrainWriteBuffer();
 
     // Read a line at each serial port.
     std::getline(serial_stream_1, read_string_1);

--- a/examples/serial_stream_read_write.cpp
+++ b/examples/serial_stream_read_write.cpp
@@ -147,6 +147,7 @@ int main()
     serial_stream_1.Close();
     serial_stream_2.Close();
 
+    // Successful program completion.
     std::cout << "The example program successfully completed!" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/examples/serial_stream_write.cpp
+++ b/examples/serial_stream_write.cpp
@@ -74,6 +74,9 @@ int main(int argc, char** argv)
         // Write the data to the serial port.
         serial_stream.write(&data_byte, 1);
 
+        // Wait until the data has actually been transmitted.
+        serial_stream.DrainWriteBuffer();
+
         // Print to the terminal what is being written to the serial port.
         std::cout << data_byte;
     }

--- a/examples/serial_stream_write.cpp
+++ b/examples/serial_stream_write.cpp
@@ -79,6 +79,6 @@ int main(int argc, char** argv)
     }
 
     // Successful program completion.
-    std::cout << std::endl << "Done." << std::endl;
+    std::cout << "The example program successfully completed!" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/sip/SerialPort.sip
+++ b/sip/SerialPort.sip
@@ -106,19 +106,9 @@ public:
     int
     GetFileDescriptor();
 
+    // NOTE: There is not a Python equivalent to std::vector.
     // std::vector<std::string>
     // GetAvailableSerialPorts();
-
-    // NOTE: Python3 provides a mechanism for method overloading, however Python2 does not.
-    // void
-    // Read(char&              charBuffer,
-    //      const unsigned int numberOfBytes = 0,
-    //      const unsigned int msTimeout  = 0);
-
-    void
-    Read(unsigned char&     charBuffer,
-         const unsigned int numberOfBytes = 0,
-         const unsigned int msTimeout  = 0);
 
     void
     Read(LibSerial::DataBuffer& dataBuffer,
@@ -144,27 +134,18 @@ public:
              const char         lineTerminator = 10, // Sip does not like '\n'
              const unsigned int msTimeout = 0);
 
-    // NOTE: Python3 provides a mechanism for method overloading, however Python2 does not.
-    // void
-    // Write(const char*        charBuffer,
-    //       const unsigned int numberOfBytes);
-    
-    void
-    Write(const unsigned char* charBuffer,
-          const unsigned int   numberOfBytes);
-    
     void
     Write(const LibSerial::DataBuffer& dataBuffer);
 
     void
     Write(const std::string& dataString);
 
+    void
+    WriteByte(const char charbuffer);
+
     // NOTE: Python3 provides a mechanism for method overloading, however Python2 does not.
     // void
-    // WriteByte(const char charbuffer);
-
-    void
-    WriteByte(const unsigned char charbuffer);
+    // WriteByte(const unsigned char charbuffer);
 
 private:
     SerialPort(const SerialPort& otherSerialPort);

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -258,17 +258,18 @@ namespace LibSerial
          *         each available serial port. 
          */
         std::vector<std::string> GetAvailableSerialPorts();
-
         /**
          * @brief Reads the specified number of bytes from the serial port.
-         *        The method will timeout if no data is received in the specified
-         *        number of milliseconds (msTimeout). If msTimeout is 0, then
-         *        this method will block until all requested bytes are
-         *        received. If numberOfBytes is zero, then this method will keep
-         *        reading data till no more data is available at the serial port.
-         *        In all cases, all read data is available in dataBuffer on
-         *        return from this method.
-         * @param dataBuffer The data buffer to place serial data into.
+         *        The method will timeout if no data is received in the
+         *        specified number of milliseconds (msTimeout). If msTimeout
+         *        is zero, then the method will block until all requested bytes
+         *        are received. If numberOfBytes is zero and msTimeout is
+         *        non-zero,  the method will continue receiving data for the
+         *        specified of milliseconds. If numberOfBytes is zero and
+         *        msTimeout is zero, the method will return immediately. In all
+         *        cases, any data received remains available in the dataBuffer
+         *        on return from this method.
+         * @param dataBuffer The data buffer to place data into.
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
@@ -283,7 +284,7 @@ namespace LibSerial
          *        this method will block until all requested bytes are
          *        received. If numberOfBytes is zero, then this method will keep
          *        reading data till no more data is available at the serial port.
-         *        In all cases, all read data is available in dataBuffer on
+         *        In all cases, all read data is available in dataString on
          *        return from this method.
          * @param dataString The data string read from the serial port.
          * @param numberOfBytes The number of bytes to read before returning.
@@ -291,7 +292,7 @@ namespace LibSerial
          */
         void Read(std::string& dataString,
                   const size_t numberOfBytes = 0,
-                  const size_t msTimeout  = 0);
+                  const size_t msTimeout = 0);
 
         /**
          * @brief Reads a single byte from the serial port.
@@ -336,8 +337,8 @@ namespace LibSerial
                       const size_t  msTimeout = 0);
 
         /**
-         * @brief Writes a DataBuffer vector to the serial port.
-         * @param dataBuffer The DataBuffer vector to be written to the serial port.
+         * @brief Writes a DataBuffer to the serial port.
+         * @param dataBuffer The DataBuffer to write to the serial port.
          */
         void Write(const DataBuffer& dataBuffer);
 
@@ -349,15 +350,15 @@ namespace LibSerial
 
         /**
          * @brief Writes a single byte to the serial port.
-         * @param charbuffer The byte to be written to the serial port.
+         * @param charBuffer The byte to be written to the serial port.
          */
-        void WriteByte(const char charbuffer);
+        void WriteByte(const char charBuffer);
 
         /**
          * @brief Writes a single byte to the serial port.
-         * @param charbuffer The byte to be written to the serial port.
+         * @param charBuffer The byte to be written to the serial port.
          */
-        void WriteByte(const unsigned char charbuffer);
+        void WriteByte(const unsigned char charBuffer);
 
     private:
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -2114,6 +2114,10 @@ namespace LibSerial
             if (msTimeout > 0 &&
                 elapsed_ms > msTimeout)
             {
+                // Free memory pointed to by the char_buffer and null the char_buffer pointer.
+                delete [] char_buffer;
+                char_buffer = NULL;
+
                 throw ReadTimeout(ERR_MSG_READ_TIMEOUT);
             }
         }
@@ -2237,6 +2241,10 @@ namespace LibSerial
             if (msTimeout > 0 &&
                 elapsed_ms > msTimeout)
             {
+                // Free memory pointed to by the char_buffer and null the char_buffer pointer.
+                delete [] char_buffer;
+                char_buffer = NULL;
+
                 throw ReadTimeout(ERR_MSG_READ_TIMEOUT);
             }
         }

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -84,6 +84,11 @@ namespace LibSerial
         void Close();
 
         /**
+         * @brief Waits until the write buffer is drained and then returns.
+         */
+        void DrainWriteBuffer();
+
+        /**
          * @brief Flushes the serial port input buffer.
          */
         void FlushInputBuffer();
@@ -466,6 +471,13 @@ namespace LibSerial
     SerialPort::Close()
     {
         mImpl->Close();
+        return;
+    }
+
+    void
+    SerialPort::DrainWriteBuffer()
+    {
+        mImpl->DrainWriteBuffer();
         return;
     }
 
@@ -861,6 +873,24 @@ namespace LibSerial
 
         // Set the file descriptor to an invalid value, -1. 
         mFileDescriptor = -1;
+        return;
+    }
+
+    inline
+    void
+    SerialPort::Implementation::DrainWriteBuffer()
+    {
+        // Throw an exception if the serial port is not open.
+        if (!this->IsOpen())
+        {
+            throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
+        }
+
+        if (tcdrain(this->mFileDescriptor) < 0)
+        {
+            throw std::runtime_error(std::strerror(errno));
+        }
+
         return;
     }
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -2055,7 +2055,7 @@ namespace LibSerial
                                &dataBuffer[number_of_bytes_read],
                                number_of_bytes_remaining);
 
-            if (read_result >= 0)
+            if (read_result > 0)
             {
                 number_of_bytes_read += read_result;
 
@@ -2069,7 +2069,7 @@ namespace LibSerial
                     }
                 }
             }
-            else if (read_result < 0 &&
+            else if (read_result <= 0 &&
                      errno != EWOULDBLOCK)
             {
                 throw std::runtime_error(std::strerror(errno));
@@ -2089,6 +2089,11 @@ namespace LibSerial
             if (msTimeout > 0 &&
                 elapsed_ms > msTimeout)
             {
+                if (numberOfBytes == 0)
+                {
+                    dataBuffer.resize(number_of_bytes_read);
+                }
+
                 throw ReadTimeout(ERR_MSG_READ_TIMEOUT);
             }
         }
@@ -2151,7 +2156,7 @@ namespace LibSerial
                                &dataString[number_of_bytes_read],
                                number_of_bytes_remaining);
 
-            if (read_result >= 0)
+            if (read_result > 0)
             {
                 number_of_bytes_read += read_result;
 
@@ -2165,7 +2170,7 @@ namespace LibSerial
                     }
                 }
             }
-            else if (read_result < 0 &&
+            else if (read_result <= 0 &&
                      errno != EWOULDBLOCK)
             {
                 throw std::runtime_error(std::strerror(errno));
@@ -2185,6 +2190,11 @@ namespace LibSerial
             if (msTimeout > 0 &&
                 elapsed_ms > msTimeout)
             {
+                if (numberOfBytes == 0)
+                {
+                    dataString.resize(number_of_bytes_read);
+                }
+
                 throw ReadTimeout(ERR_MSG_READ_TIMEOUT);
             }
         }

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -86,167 +86,167 @@ namespace LibSerial
         /**
          * @brief Flushes the serial port input buffer.
          */
-        void FlushInputBuffer() const;
+        void FlushInputBuffer();
 
         /**
          * @brief Flushes the serial port output buffer.
          */
-        void FlushOutputBuffer() const;
+        void FlushOutputBuffer();
 
         /**
          * @brief Flushes the serial port input and output buffers.
          */
-        void FlushIOBuffers() const;
+        void FlushIOBuffers();
 
         /**
          * @brief Determines if data is available at the serial port.
          */
-        bool IsDataAvailable() const;
+        bool IsDataAvailable();
 
         /**
          * @brief Determines if the serial port is open for I/O.
          * @return Returns true iff the serial port is open.
          */
-        bool IsOpen() const;
+        bool IsOpen();
 
         /**
          * @brief Sets all serial port paramters to their default values.
          */
-        void SetDefaultSerialPortParameters() const;
+        void SetDefaultSerialPortParameters();
 
         /**
          * @brief Sets the baud rate for the serial port to the specified value
          * @param baudRate The baud rate to be set for the serial port.
          */
-        void SetBaudRate(const BaudRate& baudRate) const;
+        void SetBaudRate(const BaudRate& baudRate);
 
         /**
          * @brief Gets the current baud rate for the serial port.
          * @return Returns the baud rate.
          */
-        BaudRate GetBaudRate() const;
+        BaudRate GetBaudRate();
 
         /**
          * @brief Sets the character size for the serial port.
          * @param characterSize The character size to be set.
          */
-        void SetCharacterSize(const CharacterSize& characterSize) const;
+        void SetCharacterSize(const CharacterSize& characterSize);
 
         /**
          * @brief Gets the character size being used for serial communication.
          * @return Returns the current character size. 
          */
-        CharacterSize GetCharacterSize() const;
+        CharacterSize GetCharacterSize();
 
         /**
          * @brief Sets flow control for the serial port.
          * @param flowControlType The flow control type to be set.
          */
-        void SetFlowControl(const FlowControl& flowControlType) const;
+        void SetFlowControl(const FlowControl& flowControlType);
 
         /**
          * @brief Get the current flow control setting.
          * @return Returns the flow control type of the serial port.
          */
-        FlowControl GetFlowControl() const;
+        FlowControl GetFlowControl();
 
         /**
          * @brief Sets the parity type for the serial port.
          * @param parityType The parity type to be set.
          */
-        void SetParity(const Parity& parityType) const;
+        void SetParity(const Parity& parityType);
 
         /**
          * @brief Gets the parity type for the serial port.
          * @return Returns the parity type.
          */
-        Parity GetParity() const;
+        Parity GetParity();
 
         /**
          * @brief Sets the number of stop bits to be used with the serial port.
          * @param stopBits The number of stop bits to set.
          */
-        void SetStopBits(const StopBits& stopBits) const;
+        void SetStopBits(const StopBits& stopBits);
 
         /**
          * @brief Gets the number of stop bits currently being used by the serial
          * @return Returns the number of stop bits.
          */
-        StopBits GetStopBits() const;
+        StopBits GetStopBits();
 
         /**
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(const short vmin) const;
+        void SetVMin(const short vmin);
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
          *        minimum number of characters for non-canonical reads.
          * @return Returns the minimum number of characters for non-canonical reads.
          */
-        short GetVMin() const;
+        short GetVMin();
 
         /** 
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          */
-        void SetVTime(const short vtime) const;
+        void SetVTime(const short vtime);
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds. 
          */
-        short GetVTime() const;
+        short GetVTime();
 
         /**
          * @brief Sets the serial port DTR line status.
          * @param dtrState The state to set the DTR line
          */
-        void SetDTR(const bool dtrState) const;
+        void SetDTR(const bool dtrState);
 
         /**
          * @brief Gets the serial port DTR line status.
          * @return Returns true iff the status of the DTR line is high.
          */
-        bool GetDTR() const;
+        bool GetDTR();
 
         /**
          * @brief Sets the serial port RTS line status.
          * @param rtsState The state to set the RTS line
          */
-        void SetRTS(const bool rtsState) const;
+        void SetRTS(const bool rtsState);
 
         /**
          * @brief Gets the serial port RTS line status.
          * @return Returns true iff the status of the RTS line is high.
          */
-        bool GetRTS() const;
+        bool GetRTS();
 
         /**
          * @brief Gets the serial port CTS line status.
          * @return Returns true iff the status of the CTS line is high.
          */
-        bool GetCTS() const;
+        bool GetCTS();
 
         /**
          * @brief Gets the serial port DSR line status.
          * @return Returns true iff the status of the DSR line is high.
          */
-        bool GetDSR() const;
+        bool GetDSR();
 
         /**
          * @brief Gets the serial port file descriptor.
          * @return Returns the serial port file descriptor.
          */
-        int GetFileDescriptor() const;
+        int GetFileDescriptor();
 
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
-        std::vector<std::string> GetAvailableSerialPorts() const;
+        std::vector<std::string> GetAvailableSerialPorts();
 
         /**
          * @brief Reads the specified number of bytes from the serial port.
@@ -408,7 +408,7 @@ namespace LibSerial
          *        call to this method.
          */
         void SetModemControlLine(const int modemLine,
-                                 const bool lineState) const;
+                                 const bool lineState);
 
         /**
          * @brief Get the current state of the specified modem control line.
@@ -417,45 +417,45 @@ namespace LibSerial
          * @return True if the specified line is currently set and false
          *         otherwise.
          */
-        bool GetModemControlLine(const int modemLine) const;
+        bool GetModemControlLine(const int modemLine);
 
         /**
          * @brief Sets the current state of the serial port blocking status.
          * @param blockingStatus The serial port blocking status to be set,
          *        true if to be set blocking, false if to be set non-blocking.
          */
-        void SetSerialPortBlockingStatus(const bool blockingStatus) const;
+        void SetSerialPortBlockingStatus(const bool blockingStatus);
 
         /**
          * @brief Gets the current state of the serial port blocking status.
          * @return True if port is blocking, false if port non-blocking.
          */
-        bool GetSerialPortBlockingStatus() const;
+        bool GetSerialPortBlockingStatus();
 
         /**
          * @brief Sets the default Linux specific line discipline modes.
          */
-        void SetDefaultLinuxSpecificModes() const;
+        void SetDefaultLinuxSpecificModes();
 
         /**
          * @brief Sets the default serial port input modes.
          */
-        void SetDefaultInputModes() const;
+        void SetDefaultInputModes();
 
         /**
          * @brief Sets the default serial port output modes.
          */
-        void SetDefaultOutputModes() const;
+        void SetDefaultOutputModes();
 
         /**
          * @brief Sets the default serial port control modes.
          */
-        void SetDefaultControlModes() const;
+        void SetDefaultControlModes();
 
         /**
          * @brief Sets the default serial port local modes.
          */
-        void SetDefaultLocalModes() const;
+        void SetDefaultLocalModes();
 
         /**
          * @brief The file descriptor corresponding to the serial port.
@@ -520,182 +520,182 @@ namespace LibSerial
     }
 
     void
-    SerialPort::FlushInputBuffer() const
+    SerialPort::FlushInputBuffer()
     {
         mImpl->FlushInputBuffer();
         return;
     }
 
     void
-    SerialPort::FlushOutputBuffer() const
+    SerialPort::FlushOutputBuffer()
     {
         mImpl->FlushOutputBuffer();
         return;
     }
 
     void
-    SerialPort::FlushIOBuffers() const
+    SerialPort::FlushIOBuffers()
     {
         mImpl->FlushIOBuffers();
         return;
     }
 
     bool
-    SerialPort::IsDataAvailable() const
+    SerialPort::IsDataAvailable()
     {
         return mImpl->IsDataAvailable();
     }
 
     bool
-    SerialPort::IsOpen() const
+    SerialPort::IsOpen()
     {
         return mImpl->IsOpen();
     }
 
     void
-    SerialPort::SetDefaultSerialPortParameters() const
+    SerialPort::SetDefaultSerialPortParameters()
     {
         mImpl->SetDefaultSerialPortParameters();
         return;
     }
 
     void
-    SerialPort::SetBaudRate(const BaudRate& baudRate) const
+    SerialPort::SetBaudRate(const BaudRate& baudRate)
     {
         mImpl->SetBaudRate(baudRate);
         return;
     }
 
     BaudRate
-    SerialPort::GetBaudRate() const
+    SerialPort::GetBaudRate()
     {
         return mImpl->GetBaudRate();
     }
 
     void
-    SerialPort::SetCharacterSize(const CharacterSize& characterSize) const
+    SerialPort::SetCharacterSize(const CharacterSize& characterSize)
     {
         mImpl->SetCharacterSize(characterSize);
         return;
     }
 
     CharacterSize
-    SerialPort::GetCharacterSize() const
+    SerialPort::GetCharacterSize()
     {
         return mImpl->GetCharacterSize();
     }
 
     void
-    SerialPort::SetFlowControl(const FlowControl& flowControlType) const
+    SerialPort::SetFlowControl(const FlowControl& flowControlType)
     {
         mImpl->SetFlowControl(flowControlType);
         return;
     }
 
     FlowControl
-    SerialPort::GetFlowControl() const
+    SerialPort::GetFlowControl()
     {
         return mImpl->GetFlowControl();
     }
 
     void
-    SerialPort::SetParity(const Parity& parityType) const
+    SerialPort::SetParity(const Parity& parityType)
     {
         mImpl->SetParity(parityType);
         return;
     }
 
     Parity
-    SerialPort::GetParity() const
+    SerialPort::GetParity()
     {
         return mImpl->GetParity();
     }
 
     void
-    SerialPort::SetStopBits(const StopBits& stopBits) const
+    SerialPort::SetStopBits(const StopBits& stopBits)
     {
         mImpl->SetStopBits(stopBits);
         return;
     }
 
     StopBits
-    SerialPort::GetStopBits() const
+    SerialPort::GetStopBits()
     {
         return mImpl->GetStopBits();
     }
 
     void
-    SerialPort::SetVMin(const short vmin) const
+    SerialPort::SetVMin(const short vmin)
     {
         mImpl->SetVMin(vmin);
         return;
     }
 
     short
-    SerialPort::GetVMin() const
+    SerialPort::GetVMin()
     {
         return mImpl->GetVMin();
     }
 
     void
-    SerialPort::SetVTime(const short vtime) const
+    SerialPort::SetVTime(const short vtime)
     {
         mImpl->SetVTime(vtime);
         return;
     }
 
     short
-    SerialPort::GetVTime() const
+    SerialPort::GetVTime()
     {
         return mImpl->GetVTime();
     }
 
     void
-    SerialPort::SetDTR(const bool dtrState) const
+    SerialPort::SetDTR(const bool dtrState)
     {
         mImpl->SetDTR(dtrState);
         return;
     }
 
     bool
-    SerialPort::GetDTR() const
+    SerialPort::GetDTR()
     {
         return mImpl->GetDTR();
     }
 
     void
-    SerialPort::SetRTS(const bool rtsState) const
+    SerialPort::SetRTS(const bool rtsState)
     {
         mImpl->SetRTS(rtsState);
         return;
     }
 
     bool
-    SerialPort::GetRTS() const
+    SerialPort::GetRTS()
     {
         return mImpl->GetRTS();
     }
 
     bool
-    SerialPort::GetCTS() const
+    SerialPort::GetCTS()
     {
         return mImpl->GetCTS();
     }
 
     bool
-    SerialPort::GetDSR() const
+    SerialPort::GetDSR()
     {
         return mImpl->GetDSR();
     }
 
     int
-    SerialPort::GetFileDescriptor() const
+    SerialPort::GetFileDescriptor()
     {
         return mImpl->GetFileDescriptor();
     }
 
     std::vector<std::string>
-    SerialPort::GetAvailableSerialPorts() const
+    SerialPort::GetAvailableSerialPorts()
     {
         return mImpl->GetAvailableSerialPorts();
     }
@@ -956,7 +956,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::FlushInputBuffer() const
+    SerialPort::Implementation::FlushInputBuffer()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -974,7 +974,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::FlushOutputBuffer() const
+    SerialPort::Implementation::FlushOutputBuffer()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -992,7 +992,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::FlushIOBuffers() const
+    SerialPort::Implementation::FlushIOBuffers()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1010,14 +1010,14 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::IsOpen() const
+    SerialPort::Implementation::IsOpen()
     {
         return (this->mFileDescriptor != -1);
     }
 
     inline
     bool
-    SerialPort::Implementation::IsDataAvailable() const
+    SerialPort::Implementation::IsDataAvailable()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1043,7 +1043,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialPort::Implementation::SetDefaultSerialPortParameters() const
+    SerialPort::Implementation::SetDefaultSerialPortParameters()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1073,7 +1073,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetBaudRate(const BaudRate& baudRate) const
+    SerialPort::Implementation::SetBaudRate(const BaudRate& baudRate)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1112,7 +1112,7 @@ namespace LibSerial
 
     inline
     BaudRate
-    SerialPort::Implementation::GetBaudRate() const
+    SerialPort::Implementation::GetBaudRate()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1148,7 +1148,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetCharacterSize(const CharacterSize& characterSize) const
+    SerialPort::Implementation::SetCharacterSize(const CharacterSize& characterSize)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1200,7 +1200,7 @@ namespace LibSerial
 
     inline
     CharacterSize
-    SerialPort::Implementation::GetCharacterSize() const
+    SerialPort::Implementation::GetCharacterSize()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1224,7 +1224,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetFlowControl(const FlowControl& flowControlType) const
+    SerialPort::Implementation::SetFlowControl(const FlowControl& flowControlType)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1288,7 +1288,7 @@ namespace LibSerial
 
     inline
     FlowControl
-    SerialPort::Implementation::GetFlowControl() const
+    SerialPort::Implementation::GetFlowControl()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1338,7 +1338,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetParity(const Parity& parityType) const
+    SerialPort::Implementation::SetParity(const Parity& parityType)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1391,7 +1391,7 @@ namespace LibSerial
 
     inline
     Parity
-    SerialPort::Implementation::GetParity() const
+    SerialPort::Implementation::GetParity()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1432,7 +1432,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetStopBits(const StopBits& stopBits) const
+    SerialPort::Implementation::SetStopBits(const StopBits& stopBits)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1477,7 +1477,7 @@ namespace LibSerial
 
     inline
     StopBits
-    SerialPort::Implementation::GetStopBits() const
+    SerialPort::Implementation::GetStopBits()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1509,7 +1509,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialPort::Implementation::SetVMin(const short vmin) const
+    SerialPort::Implementation::SetVMin(const short vmin)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1547,7 +1547,7 @@ namespace LibSerial
 
     inline
     short 
-    SerialPort::Implementation::GetVMin() const
+    SerialPort::Implementation::GetVMin()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1570,7 +1570,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialPort::Implementation::SetVTime(const short vtime) const
+    SerialPort::Implementation::SetVTime(const short vtime)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1608,7 +1608,7 @@ namespace LibSerial
 
     inline
     short 
-    SerialPort::Implementation::GetVTime() const
+    SerialPort::Implementation::GetVTime()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1631,7 +1631,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDTR(const bool dtrState) const
+    SerialPort::Implementation::SetDTR(const bool dtrState)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1646,7 +1646,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetDTR() const
+    SerialPort::Implementation::GetDTR()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1659,7 +1659,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetRTS(const bool rtsState) const
+    SerialPort::Implementation::SetRTS(const bool rtsState)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1674,7 +1674,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetRTS() const
+    SerialPort::Implementation::GetRTS()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1687,7 +1687,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetCTS() const
+    SerialPort::Implementation::GetCTS()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1700,7 +1700,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetDSR() const
+    SerialPort::Implementation::GetDSR()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1713,7 +1713,7 @@ namespace LibSerial
 
     inline
     int
-    SerialPort::Implementation::GetFileDescriptor() const
+    SerialPort::Implementation::GetFileDescriptor()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1726,7 +1726,7 @@ namespace LibSerial
 
     inline
     std::vector<std::string>
-    SerialPort::Implementation::GetAvailableSerialPorts() const
+    SerialPort::Implementation::GetAvailableSerialPorts()
     {
         const int array_size = 3;
         int file_descriptor = -1;
@@ -1775,7 +1775,7 @@ namespace LibSerial
     inline
     void
     SerialPort::Implementation::SetModemControlLine(const int  modemLine,
-                                                    const bool lineState) const
+                                                    const bool lineState)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1827,7 +1827,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetModemControlLine(const int modemLine) const
+    SerialPort::Implementation::GetModemControlLine(const int modemLine)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1865,7 +1865,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetSerialPortBlockingStatus(const bool blockingStatus) const
+    SerialPort::Implementation::SetSerialPortBlockingStatus(const bool blockingStatus)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1897,7 +1897,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetSerialPortBlockingStatus() const
+    SerialPort::Implementation::GetSerialPortBlockingStatus()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1923,7 +1923,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultLinuxSpecificModes() const
+    SerialPort::Implementation::SetDefaultLinuxSpecificModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1958,7 +1958,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultInputModes() const
+    SerialPort::Implementation::SetDefaultInputModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1992,7 +1992,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultOutputModes() const
+    SerialPort::Implementation::SetDefaultOutputModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -2025,7 +2025,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultControlModes() const
+    SerialPort::Implementation::SetDefaultControlModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -2059,7 +2059,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultLocalModes() const
+    SerialPort::Implementation::SetDefaultLocalModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -62,7 +62,8 @@ namespace LibSerial
                        const StopBits&      stopBits);
 
         /**
-         * @brief Default Destructor.
+         * @brief Default Destructor for a SerialPort object. Closes the
+         *        serial port associated with mFileDescriptor if open.
          */
         ~Implementation();
 
@@ -85,167 +86,167 @@ namespace LibSerial
         /**
          * @brief Flushes the serial port input buffer.
          */
-        void FlushInputBuffer();
+        void FlushInputBuffer() const;
 
         /**
          * @brief Flushes the serial port output buffer.
          */
-        void FlushOutputBuffer();
+        void FlushOutputBuffer() const;
 
         /**
          * @brief Flushes the serial port input and output buffers.
          */
-        void FlushIOBuffers();
+        void FlushIOBuffers() const;
 
         /**
          * @brief Determines if data is available at the serial port.
          */
-        bool IsDataAvailable();
+        bool IsDataAvailable() const;
 
         /**
          * @brief Determines if the serial port is open for I/O.
          * @return Returns true iff the serial port is open.
          */
-        bool IsOpen();
+        bool IsOpen() const;
 
         /**
          * @brief Sets all serial port paramters to their default values.
          */
-        void SetDefaultSerialPortParameters();
+        void SetDefaultSerialPortParameters() const;
 
         /**
          * @brief Sets the baud rate for the serial port to the specified value
          * @param baudRate The baud rate to be set for the serial port.
          */
-        void SetBaudRate(const BaudRate& baudRate);
+        void SetBaudRate(const BaudRate& baudRate) const;
 
         /**
          * @brief Gets the current baud rate for the serial port.
          * @return Returns the baud rate.
          */
-        BaudRate GetBaudRate();
+        BaudRate GetBaudRate() const;
 
         /**
          * @brief Sets the character size for the serial port.
          * @param characterSize The character size to be set.
          */
-        void SetCharacterSize(const CharacterSize& characterSize);
+        void SetCharacterSize(const CharacterSize& characterSize) const;
 
         /**
          * @brief Gets the character size being used for serial communication.
          * @return Returns the current character size. 
          */
-        CharacterSize GetCharacterSize();
+        CharacterSize GetCharacterSize() const;
 
         /**
          * @brief Sets flow control for the serial port.
          * @param flowControlType The flow control type to be set.
          */
-        void SetFlowControl(const FlowControl& flowControlType);
+        void SetFlowControl(const FlowControl& flowControlType) const;
 
         /**
          * @brief Get the current flow control setting.
          * @return Returns the flow control type of the serial port.
          */
-        FlowControl GetFlowControl();
+        FlowControl GetFlowControl() const;
 
         /**
          * @brief Sets the parity type for the serial port.
          * @param parityType The parity type to be set.
          */
-        void SetParity(const Parity& parityType);
+        void SetParity(const Parity& parityType) const;
 
         /**
          * @brief Gets the parity type for the serial port.
          * @return Returns the parity type.
          */
-        Parity GetParity();
+        Parity GetParity() const;
 
         /**
          * @brief Sets the number of stop bits to be used with the serial port.
          * @param stopBits The number of stop bits to set.
          */
-        void SetStopBits(const StopBits& stopBits);
+        void SetStopBits(const StopBits& stopBits) const;
 
         /**
          * @brief Gets the number of stop bits currently being used by the serial
          * @return Returns the number of stop bits.
          */
-        StopBits GetStopBits();
+        StopBits GetStopBits() const;
 
         /**
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(const short vmin);
+        void SetVMin(const short vmin) const;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
          *        minimum number of characters for non-canonical reads.
          * @return Returns the minimum number of characters for non-canonical reads.
          */
-        short GetVMin();
+        short GetVMin() const;
 
         /** 
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          */
-        void SetVTime(const short vtime);
+        void SetVTime(const short vtime) const;
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds. 
          */
-        short GetVTime();
+        short GetVTime() const;
 
         /**
          * @brief Sets the serial port DTR line status.
          * @param dtrState The state to set the DTR line
          */
-        void SetDTR(const bool dtrState);
+        void SetDTR(const bool dtrState) const;
 
         /**
          * @brief Gets the serial port DTR line status.
          * @return Returns true iff the status of the DTR line is high.
          */
-        bool GetDTR();
+        bool GetDTR() const;
 
         /**
          * @brief Sets the serial port RTS line status.
          * @param rtsState The state to set the RTS line
          */
-        void SetRTS(const bool rtsState);
+        void SetRTS(const bool rtsState) const;
 
         /**
          * @brief Gets the serial port RTS line status.
          * @return Returns true iff the status of the RTS line is high.
          */
-        bool GetRTS();
+        bool GetRTS() const;
 
         /**
          * @brief Gets the serial port CTS line status.
          * @return Returns true iff the status of the CTS line is high.
          */
-        bool GetCTS();
+        bool GetCTS() const;
 
         /**
          * @brief Gets the serial port DSR line status.
          * @return Returns true iff the status of the DSR line is high.
          */
-        bool GetDSR();
+        bool GetDSR() const;
 
         /**
          * @brief Gets the serial port file descriptor.
          * @return Returns the serial port file descriptor.
          */
-        int GetFileDescriptor();
+        int GetFileDescriptor() const;
 
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
-        std::vector<std::string> GetAvailableSerialPorts();
+        std::vector<std::string> GetAvailableSerialPorts() const;
 
         /**
          * @brief Reads the specified number of bytes from the serial port.
@@ -407,7 +408,7 @@ namespace LibSerial
          *        call to this method.
          */
         void SetModemControlLine(const int modemLine,
-                                 const bool lineState);
+                                 const bool lineState) const;
 
         /**
          * @brief Get the current state of the specified modem control line.
@@ -416,45 +417,45 @@ namespace LibSerial
          * @return True if the specified line is currently set and false
          *         otherwise.
          */
-        bool GetModemControlLine(const int modemLine);
+        bool GetModemControlLine(const int modemLine) const;
 
         /**
          * @brief Sets the current state of the serial port blocking status.
          * @param blockingStatus The serial port blocking status to be set,
          *        true if to be set blocking, false if to be set non-blocking.
          */
-        void SetSerialPortBlockingStatus(const bool blockingStatus);
+        void SetSerialPortBlockingStatus(const bool blockingStatus) const;
 
         /**
          * @brief Gets the current state of the serial port blocking status.
          * @return True if port is blocking, false if port non-blocking.
          */
-        bool GetSerialPortBlockingStatus();
+        bool GetSerialPortBlockingStatus() const;
 
         /**
          * @brief Sets the default Linux specific line discipline modes.
          */
-        void SetDefaultLinuxSpecificModes();
+        void SetDefaultLinuxSpecificModes() const;
 
         /**
          * @brief Sets the default serial port input modes.
          */
-        void SetDefaultInputModes();
+        void SetDefaultInputModes() const;
 
         /**
          * @brief Sets the default serial port output modes.
          */
-        void SetDefaultOutputModes();
+        void SetDefaultOutputModes() const;
 
         /**
          * @brief Sets the default serial port control modes.
          */
-        void SetDefaultControlModes();
+        void SetDefaultControlModes() const;
 
         /**
          * @brief Sets the default serial port local modes.
          */
-        void SetDefaultLocalModes();
+        void SetDefaultLocalModes() const;
 
         /**
          * @brief The file descriptor corresponding to the serial port.
@@ -519,182 +520,182 @@ namespace LibSerial
     }
 
     void
-    SerialPort::FlushInputBuffer()
+    SerialPort::FlushInputBuffer() const
     {
         mImpl->FlushInputBuffer();
         return;
     }
 
     void
-    SerialPort::FlushOutputBuffer()
+    SerialPort::FlushOutputBuffer() const
     {
         mImpl->FlushOutputBuffer();
         return;
     }
 
     void
-    SerialPort::FlushIOBuffers()
+    SerialPort::FlushIOBuffers() const
     {
         mImpl->FlushIOBuffers();
         return;
     }
 
     bool
-    SerialPort::IsDataAvailable()
+    SerialPort::IsDataAvailable() const
     {
         return mImpl->IsDataAvailable();
     }
 
     bool
-    SerialPort::IsOpen()
+    SerialPort::IsOpen() const
     {
         return mImpl->IsOpen();
     }
 
     void
-    SerialPort::SetDefaultSerialPortParameters()
+    SerialPort::SetDefaultSerialPortParameters() const
     {
         mImpl->SetDefaultSerialPortParameters();
         return;
     }
 
     void
-    SerialPort::SetBaudRate(const BaudRate& baudRate)
+    SerialPort::SetBaudRate(const BaudRate& baudRate) const
     {
         mImpl->SetBaudRate(baudRate);
         return;
     }
 
     BaudRate
-    SerialPort::GetBaudRate()
+    SerialPort::GetBaudRate() const
     {
         return mImpl->GetBaudRate();
     }
 
     void
-    SerialPort::SetCharacterSize(const CharacterSize& characterSize)
+    SerialPort::SetCharacterSize(const CharacterSize& characterSize) const
     {
         mImpl->SetCharacterSize(characterSize);
         return;
     }
 
     CharacterSize
-    SerialPort::GetCharacterSize()
+    SerialPort::GetCharacterSize() const
     {
         return mImpl->GetCharacterSize();
     }
 
     void
-    SerialPort::SetFlowControl(const FlowControl& flowControlType)
+    SerialPort::SetFlowControl(const FlowControl& flowControlType) const
     {
         mImpl->SetFlowControl(flowControlType);
         return;
     }
 
     FlowControl
-    SerialPort::GetFlowControl()
+    SerialPort::GetFlowControl() const
     {
         return mImpl->GetFlowControl();
     }
 
     void
-    SerialPort::SetParity(const Parity& parityType)
+    SerialPort::SetParity(const Parity& parityType) const
     {
         mImpl->SetParity(parityType);
         return;
     }
 
     Parity
-    SerialPort::GetParity()
+    SerialPort::GetParity() const
     {
         return mImpl->GetParity();
     }
 
     void
-    SerialPort::SetStopBits(const StopBits& stopBits)
+    SerialPort::SetStopBits(const StopBits& stopBits) const
     {
         mImpl->SetStopBits(stopBits);
         return;
     }
 
     StopBits
-    SerialPort::GetStopBits()
+    SerialPort::GetStopBits() const
     {
         return mImpl->GetStopBits();
     }
 
     void
-    SerialPort::SetVMin(const short vmin)
+    SerialPort::SetVMin(const short vmin) const
     {
         mImpl->SetVMin(vmin);
         return;
     }
 
     short
-    SerialPort::GetVMin()
+    SerialPort::GetVMin() const
     {
         return mImpl->GetVMin();
     }
 
     void
-    SerialPort::SetVTime(const short vtime)
+    SerialPort::SetVTime(const short vtime) const
     {
         mImpl->SetVTime(vtime);
         return;
     }
 
     short
-    SerialPort::GetVTime()
+    SerialPort::GetVTime() const
     {
         return mImpl->GetVTime();
     }
 
     void
-    SerialPort::SetDTR(const bool dtrState)
+    SerialPort::SetDTR(const bool dtrState) const
     {
         mImpl->SetDTR(dtrState);
         return;
     }
 
     bool
-    SerialPort::GetDTR()
+    SerialPort::GetDTR() const
     {
         return mImpl->GetDTR();
     }
 
     void
-    SerialPort::SetRTS(const bool rtsState)
+    SerialPort::SetRTS(const bool rtsState) const
     {
         mImpl->SetRTS(rtsState);
         return;
     }
 
     bool
-    SerialPort::GetRTS()
+    SerialPort::GetRTS() const
     {
         return mImpl->GetRTS();
     }
 
     bool
-    SerialPort::GetCTS()
+    SerialPort::GetCTS() const
     {
         return mImpl->GetCTS();
     }
 
     bool
-    SerialPort::GetDSR() 
+    SerialPort::GetDSR() const
     {
         return mImpl->GetDSR();
     }
 
     int
-    SerialPort::GetFileDescriptor()
+    SerialPort::GetFileDescriptor() const
     {
         return mImpl->GetFileDescriptor();
     }
 
     std::vector<std::string>
-    SerialPort::GetAvailableSerialPorts()
+    SerialPort::GetAvailableSerialPorts() const
     {
         return mImpl->GetAvailableSerialPorts();
     }
@@ -955,7 +956,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::FlushInputBuffer()
+    SerialPort::Implementation::FlushInputBuffer() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -973,7 +974,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::FlushOutputBuffer()
+    SerialPort::Implementation::FlushOutputBuffer() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -991,7 +992,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::FlushIOBuffers()
+    SerialPort::Implementation::FlushIOBuffers() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1009,14 +1010,14 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::IsOpen()
+    SerialPort::Implementation::IsOpen() const
     {
         return (this->mFileDescriptor != -1);
     }
 
     inline
     bool
-    SerialPort::Implementation::IsDataAvailable()
+    SerialPort::Implementation::IsDataAvailable() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1042,7 +1043,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialPort::Implementation::SetDefaultSerialPortParameters()
+    SerialPort::Implementation::SetDefaultSerialPortParameters() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1072,7 +1073,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetBaudRate(const BaudRate& baudRate)
+    SerialPort::Implementation::SetBaudRate(const BaudRate& baudRate) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1111,7 +1112,7 @@ namespace LibSerial
 
     inline
     BaudRate
-    SerialPort::Implementation::GetBaudRate()
+    SerialPort::Implementation::GetBaudRate() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1147,7 +1148,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetCharacterSize(const CharacterSize& characterSize)
+    SerialPort::Implementation::SetCharacterSize(const CharacterSize& characterSize) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1199,7 +1200,7 @@ namespace LibSerial
 
     inline
     CharacterSize
-    SerialPort::Implementation::GetCharacterSize()
+    SerialPort::Implementation::GetCharacterSize() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1223,7 +1224,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetFlowControl(const FlowControl& flowControlType)
+    SerialPort::Implementation::SetFlowControl(const FlowControl& flowControlType) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1287,7 +1288,7 @@ namespace LibSerial
 
     inline
     FlowControl
-    SerialPort::Implementation::GetFlowControl()
+    SerialPort::Implementation::GetFlowControl() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1337,7 +1338,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetParity(const Parity& parityType)
+    SerialPort::Implementation::SetParity(const Parity& parityType) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1390,7 +1391,7 @@ namespace LibSerial
 
     inline
     Parity
-    SerialPort::Implementation::GetParity()
+    SerialPort::Implementation::GetParity() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1431,7 +1432,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetStopBits(const StopBits& stopBits)
+    SerialPort::Implementation::SetStopBits(const StopBits& stopBits) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1476,7 +1477,7 @@ namespace LibSerial
 
     inline
     StopBits
-    SerialPort::Implementation::GetStopBits()
+    SerialPort::Implementation::GetStopBits() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1508,7 +1509,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialPort::Implementation::SetVMin(const short vmin)
+    SerialPort::Implementation::SetVMin(const short vmin) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1546,7 +1547,7 @@ namespace LibSerial
 
     inline
     short 
-    SerialPort::Implementation::GetVMin()
+    SerialPort::Implementation::GetVMin() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1569,7 +1570,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialPort::Implementation::SetVTime(const short vtime)
+    SerialPort::Implementation::SetVTime(const short vtime) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1607,7 +1608,7 @@ namespace LibSerial
 
     inline
     short 
-    SerialPort::Implementation::GetVTime() 
+    SerialPort::Implementation::GetVTime() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1630,7 +1631,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDTR(const bool dtrState)
+    SerialPort::Implementation::SetDTR(const bool dtrState) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1645,7 +1646,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetDTR()
+    SerialPort::Implementation::GetDTR() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1658,7 +1659,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetRTS(const bool rtsState)
+    SerialPort::Implementation::SetRTS(const bool rtsState) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1673,7 +1674,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetRTS()
+    SerialPort::Implementation::GetRTS() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1686,7 +1687,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetCTS()
+    SerialPort::Implementation::GetCTS() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1699,7 +1700,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetDSR()
+    SerialPort::Implementation::GetDSR() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1712,7 +1713,7 @@ namespace LibSerial
 
     inline
     int
-    SerialPort::Implementation::GetFileDescriptor()
+    SerialPort::Implementation::GetFileDescriptor() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1725,7 +1726,7 @@ namespace LibSerial
 
     inline
     std::vector<std::string>
-    SerialPort::Implementation::GetAvailableSerialPorts()
+    SerialPort::Implementation::GetAvailableSerialPorts() const
     {
         const int array_size = 3;
         int file_descriptor = -1;
@@ -1774,7 +1775,7 @@ namespace LibSerial
     inline
     void
     SerialPort::Implementation::SetModemControlLine(const int  modemLine,
-                                                    const bool lineState)
+                                                    const bool lineState) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1826,7 +1827,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetModemControlLine(const int modemLine)
+    SerialPort::Implementation::GetModemControlLine(const int modemLine) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1864,7 +1865,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetSerialPortBlockingStatus(const bool blockingStatus)
+    SerialPort::Implementation::SetSerialPortBlockingStatus(const bool blockingStatus) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1896,7 +1897,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialPort::Implementation::GetSerialPortBlockingStatus()
+    SerialPort::Implementation::GetSerialPortBlockingStatus() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1922,7 +1923,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultLinuxSpecificModes()
+    SerialPort::Implementation::SetDefaultLinuxSpecificModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1957,7 +1958,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultInputModes()
+    SerialPort::Implementation::SetDefaultInputModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1991,7 +1992,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultOutputModes()
+    SerialPort::Implementation::SetDefaultOutputModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -2024,7 +2025,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultControlModes()
+    SerialPort::Implementation::SetDefaultControlModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -2058,7 +2059,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::SetDefaultLocalModes()
+    SerialPort::Implementation::SetDefaultLocalModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -70,7 +70,7 @@ namespace LibSerial
         /**
          * @brief Opens the serial port associated with the specified
          *        file name and the specified mode.
-         * @param fileName The file name of the serial port object.
+         * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
          */

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -2048,7 +2048,7 @@ namespace LibSerial
             if (numberOfBytes == 0)
             {
                 // Add an additional element for the read() call.
-                dataBuffer.resize(number_of_bytes_read + number_of_bytes_remaining);
+                dataBuffer.resize(number_of_bytes_read + 1);
             }
 
             read_result = read(this->mFileDescriptor,
@@ -2089,13 +2089,14 @@ namespace LibSerial
             if (msTimeout > 0 &&
                 elapsed_ms > msTimeout)
             {
-                if (numberOfBytes == 0)
-                {
-                    dataBuffer.resize(number_of_bytes_read);
-                }
+                // Resize the data buffer.
+                dataBuffer.resize(number_of_bytes_read);
 
                 throw ReadTimeout(ERR_MSG_READ_TIMEOUT);
             }
+            
+            // Allow 100us for additional data to arrive.
+            usleep(100);
         }
 
         return;
@@ -2149,7 +2150,7 @@ namespace LibSerial
             if (numberOfBytes == 0)
             {
                 // Add an additional element for the read() call.
-                dataString.resize(number_of_bytes_read + number_of_bytes_remaining);
+                dataString.resize(number_of_bytes_read + 1);
             }
 
             read_result = read(this->mFileDescriptor,
@@ -2190,13 +2191,14 @@ namespace LibSerial
             if (msTimeout > 0 &&
                 elapsed_ms > msTimeout)
             {
-                if (numberOfBytes == 0)
-                {
-                    dataString.resize(number_of_bytes_read);
-                }
+                // Resize the data string.
+                dataString.resize(number_of_bytes_read);
 
                 throw ReadTimeout(ERR_MSG_READ_TIMEOUT);
             }
+
+            // Allow 100us for additional data to arrive.
+            usleep(100);
         }
 
         return;
@@ -2263,8 +2265,8 @@ namespace LibSerial
                 throw ReadTimeout(ERR_MSG_READ_TIMEOUT);
             }
 
-            // Sleep for 1ms (1000us) for data to arrive.
-            usleep(1000);
+            // Allow 100us for additional data to arrive.
+            usleep(100);
         }
 
         return;
@@ -2331,8 +2333,8 @@ namespace LibSerial
                 throw ReadTimeout(ERR_MSG_READ_TIMEOUT);
             }
 
-            // Sleep for 1ms (1000us) for data to arrive.
-            usleep(1000);
+            // Allow 100us for additional data to arrive.
+            usleep(100);
         }
 
         return;

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -261,7 +261,7 @@ namespace LibSerial
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
-        void Read(char&        charBuffer,
+        void Read(char*        charBuffer,
                   const size_t numberOfBytes = 0,
                   const size_t msTimeout = 0);
 
@@ -278,7 +278,7 @@ namespace LibSerial
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
-        void Read(unsigned char& charBuffer,
+        void Read(unsigned char* charBuffer,
                   const size_t   numberOfBytes = 0,
                   const size_t   msTimeout = 0);
 
@@ -701,7 +701,7 @@ namespace LibSerial
     }
 
     void
-    SerialPort::Read(char&        charBuffer,
+    SerialPort::Read(char*        charBuffer,
                      const size_t numberOfBytes,
                      const size_t msTimeout)
     {
@@ -712,7 +712,7 @@ namespace LibSerial
     }
 
     void
-    SerialPort::Read(unsigned char& charBuffer,
+    SerialPort::Read(unsigned char* charBuffer,
                      const size_t   numberOfBytes,
                      const size_t   msTimeout)
     {
@@ -2092,7 +2092,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::Read(char&        charBuffer,
+    SerialPort::Implementation::Read(char*        charBuffer,
                                      const size_t numberOfBytes,
                                      const size_t msTimeout)
     {
@@ -2130,7 +2130,7 @@ namespace LibSerial
             }
 
             read_result = read(this->mFileDescriptor,
-                               &charBuffer + number_of_bytes_read,
+                               charBuffer + number_of_bytes_read,
                                number_of_bytes_remaining);
             
             if (read_result > 0)
@@ -2175,7 +2175,7 @@ namespace LibSerial
 
     inline
     void
-    SerialPort::Implementation::Read(unsigned char& charBuffer,
+    SerialPort::Implementation::Read(unsigned char* charBuffer,
                                      const size_t   numberOfBytes,
                                      const size_t   msTimeout)
     {
@@ -2213,7 +2213,7 @@ namespace LibSerial
             }
 
             read_result = read(this->mFileDescriptor,
-                               &charBuffer + number_of_bytes_read,
+                               charBuffer + number_of_bytes_read,
                                number_of_bytes_remaining);
             
             if (read_result > 0)
@@ -2304,7 +2304,7 @@ namespace LibSerial
 
             for (size_t i = 0; i < number_of_bytes_remaining; i++)
             {
-                this->Read(next_char,
+                this->Read(&next_char,
                            1,
                            remaining_ms);
 
@@ -2384,7 +2384,7 @@ namespace LibSerial
 
             for (size_t i = 0; i < number_of_bytes_remaining; i++)
             {
-                this->Read(next_char,
+                this->Read(&next_char,
                            1,
                            remaining_ms);
 
@@ -2428,7 +2428,7 @@ namespace LibSerial
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
         }
 
-        this->Read(charBuffer,
+        this->Read(&charBuffer,
                    1,
                    msTimeout);
         return;
@@ -2445,7 +2445,7 @@ namespace LibSerial
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
         }
 
-        this->Read(charBuffer,
+        this->Read(&charBuffer,
                    1,
                    msTimeout);
         return;
@@ -2500,7 +2500,7 @@ namespace LibSerial
 
             remaining_ms = msTimeout - elapsed_ms;
 
-            this->Read(next_char,
+            this->Read(&next_char,
                        1,
                        remaining_ms);
 

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -286,7 +286,7 @@ namespace LibSerial
          */
         void Read(DataBuffer&  dataBuffer,
                   const size_t numberOfBytes = 0,
-                  const size_t msTimeout  = 0);
+                  const size_t msTimeout = 0);
 
         /**
          * @brief Reads the specified number of bytes from the serial port.
@@ -305,7 +305,7 @@ namespace LibSerial
          */
         void Read(std::string& dataString,
                   const size_t numberOfBytes = 0,
-                  const size_t msTimeout  = 0);
+                  const size_t msTimeout = 0);
 
         /**
          * @brief Reads a single byte from the serial port. If no data is 
@@ -349,8 +349,8 @@ namespace LibSerial
                       const size_t  msTimeout = 0);
 
         /**
-         * @brief Writes a DataBuffer vector to the serial port.
-         * @param dataBuffer The DataBuffer vector to write to the serial port.
+         * @brief Writes a DataBuffer to the serial port.
+         * @param dataBuffer The DataBuffer to write to the serial port.
          */
         void Write(const DataBuffer& dataBuffer);
 

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -88,6 +88,11 @@ namespace LibSerial
         void Close();
 
         /**
+         * @brief Waits until the write buffer is drained and then returns.
+         */
+        void DrainWriteBuffer();
+
+        /**
          * @brief Flushes the serial port input buffer.
          */
         void FlushInputBuffer();

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -90,101 +90,101 @@ namespace LibSerial
         /**
          * @brief Flushes the serial port input buffer.
          */
-        void FlushInputBuffer() const;
+        void FlushInputBuffer();
 
         /**
          * @brief Flushes the serial port output buffer.
          */
-        void FlushOutputBuffer() const;
+        void FlushOutputBuffer();
 
         /**
          * @brief Flushes the serial port input and output buffers.
          */
-        void FlushIOBuffers() const;
+        void FlushIOBuffers();
 
         /**
          * @brief Checks if data is available at the input of the serial port.
          * @return Returns true iff data is available to read.
          */
-        bool IsDataAvailable() const;
+        bool IsDataAvailable();
 
         /**
          * @brief Determines if the serial port is open for I/O.
          * @return Returns true iff the serial port is open.
          */
-        bool IsOpen() const;
+        bool IsOpen();
 
         /**
          * @brief Sets all serial port paramters to their default values.
          */
-        void SetDefaultSerialPortParameters() const;
+        void SetDefaultSerialPortParameters();
 
         /**
          * @brief Sets the baud rate for the serial port to the specified value
          * @param baudRate The baud rate to be set for the serial port.
          */
-        void SetBaudRate(const BaudRate& baudRate) const;
+        void SetBaudRate(const BaudRate& baudRate);
 
         /**
          * @brief Gets the current baud rate for the serial port.
          * @return Returns the baud rate.
          */
-        BaudRate GetBaudRate() const;
+        BaudRate GetBaudRate();
 
         /**
          * @brief Sets the character size for the serial port.
          * @param characterSize The character size to be set.
          */
-        void SetCharacterSize(const CharacterSize& characterSize) const;
+        void SetCharacterSize(const CharacterSize& characterSize);
 
         /**
          * @brief Gets the character size being used for serial communication.
          * @return Returns the current character size. 
          */
-        CharacterSize GetCharacterSize() const;
+        CharacterSize GetCharacterSize();
 
         /**
          * @brief Sets flow control for the serial port.
          * @param flowControlType The flow control type to be set.
          */
-        void SetFlowControl(const FlowControl& flowControlType) const;
+        void SetFlowControl(const FlowControl& flowControlType);
 
         /**
          * @brief Gets the current flow control setting.
          * @return Returns the flow control type of the serial port.
          */
-        FlowControl GetFlowControl() const;
+        FlowControl GetFlowControl();
 
         /**
          * @brief Sets the parity type for the serial port.
          * @param parityType The parity type to be set.
          */
-        void SetParity(const Parity& parityType) const;
+        void SetParity(const Parity& parityType);
 
         /**
          * @brief Gets the parity type for the serial port.
          * @return Returns the parity type.
          */
-        Parity GetParity() const;
+        Parity GetParity();
 
         /**
          * @brief Sets the number of stop bits to be used with the serial port.
          * @param stopBits The number of stop bits to set.
          */
-        void SetStopBits(const StopBits& stopBits) const;
+        void SetStopBits(const StopBits& stopBits);
 
         /**
          * @brief Gets the number of stop bits currently being used by the serial
          * @return Returns the number of stop bits.
          */
-        StopBits GetStopBits() const;
+        StopBits GetStopBits();
 
         /**
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @note See VMIN in man termios(3).
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(const short vmin) const;
+        void SetVMin(const short vmin);
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -192,71 +192,71 @@ namespace LibSerial
          * @return Returns the minimum number of characters for
          *         non-canonical reads.
          */
-        short GetVMin() const;
+        short GetVMin();
 
         /** 
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds.
          */
-        void SetVTime(const short vtime) const;
+        void SetVTime(const short vtime);
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds. 
          */
-        short GetVTime() const;
+        short GetVTime();
 
         /**
          * @brief Sets the DTR line to the specified value.
          * @param dtrState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetDTR(const bool dtrState = true) const;
+        void SetDTR(const bool dtrState = true);
 
         /**
          * @brief Gets the status of the DTR line.
          * @return Returns true iff the status of the DTR line is high.
          */
-        bool GetDTR() const;
+        bool GetDTR();
 
         /**
          * @brief Set the RTS line to the specified value.
          * @param rtsState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetRTS(const bool rtsState = true) const;
+        void SetRTS(const bool rtsState = true);
 
         /**
          * @brief Get the status of the RTS line.
          * @return Returns true iff the status of the RTS line is high.
          */
-        bool GetRTS() const;
+        bool GetRTS();
 
         /**
          * @brief Get the status of the CTS line.
          * @return Returns true iff the status of the CTS line is high.
          */
-        bool GetCTS() const;
+        bool GetCTS();
 
         /**
          * @brief Get the status of the DSR line.
          * @return Returns true iff the status of the DSR line is high.
          */
-        bool GetDSR() const;
+        bool GetDSR();
 
         /**
          * @brief Gets the serial port file descriptor.
          * @return Returns the serial port file descriptor.
          */
-        int GetFileDescriptor() const;
+        int GetFileDescriptor();
 
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
-        std::vector<std::string> GetAvailableSerialPorts() const;
+        std::vector<std::string> GetAvailableSerialPorts();
 
         /**
          * @brief Reads the specified number of bytes from the serial port.

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -74,7 +74,7 @@ namespace LibSerial
         /**
          * @brief Opens the serial port associated with the specified
          *        file name and the specified mode.
-         * @param fileName The file name of the serial port object.
+         * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
          */

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -257,6 +257,12 @@ namespace LibSerial
         int GetFileDescriptor();
 
         /**
+         * @brief Gets the number of bytes available in the read buffer.
+         * @return Returns the number of bytes avilable in the read buffer.
+         */
+        int GetNumberOfBytesAvailable();
+
+        /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -273,7 +273,7 @@ namespace LibSerial
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
-        void Read(char&        charBuffer,
+        void Read(char*        charBuffer,
                   const size_t numberOfBytes = 0,
                   const size_t msTimeout  = 0);
 
@@ -292,7 +292,7 @@ namespace LibSerial
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
-        void Read(unsigned char& charBuffer,
+        void Read(unsigned char* charBuffer,
                   const size_t   numberOfBytes = 0,
                   const size_t   msTimeout  = 0);
 

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -66,7 +66,8 @@ namespace LibSerial
                             const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT);
 
         /**
-         * @brief Default Destructor for a serial port object.
+         * @brief Default Destructor for a SerialPort object. Closes the
+         *        serial port associated with mFileDescriptor if open.
          */
         virtual ~SerialPort() noexcept;
 
@@ -89,101 +90,101 @@ namespace LibSerial
         /**
          * @brief Flushes the serial port input buffer.
          */
-        void FlushInputBuffer();
+        void FlushInputBuffer() const;
 
         /**
          * @brief Flushes the serial port output buffer.
          */
-        void FlushOutputBuffer();
+        void FlushOutputBuffer() const;
 
         /**
          * @brief Flushes the serial port input and output buffers.
          */
-        void FlushIOBuffers();
+        void FlushIOBuffers() const;
 
         /**
          * @brief Checks if data is available at the input of the serial port.
          * @return Returns true iff data is available to read.
          */
-        bool IsDataAvailable();
+        bool IsDataAvailable() const;
 
         /**
          * @brief Determines if the serial port is open for I/O.
          * @return Returns true iff the serial port is open.
          */
-        bool IsOpen();
+        bool IsOpen() const;
 
         /**
          * @brief Sets all serial port paramters to their default values.
          */
-        void SetDefaultSerialPortParameters();
+        void SetDefaultSerialPortParameters() const;
 
         /**
          * @brief Sets the baud rate for the serial port to the specified value
          * @param baudRate The baud rate to be set for the serial port.
          */
-        void SetBaudRate(const BaudRate& baudRate);
+        void SetBaudRate(const BaudRate& baudRate) const;
 
         /**
          * @brief Gets the current baud rate for the serial port.
          * @return Returns the baud rate.
          */
-        BaudRate GetBaudRate();
+        BaudRate GetBaudRate() const;
 
         /**
          * @brief Sets the character size for the serial port.
          * @param characterSize The character size to be set.
          */
-        void SetCharacterSize(const CharacterSize& characterSize);
+        void SetCharacterSize(const CharacterSize& characterSize) const;
 
         /**
          * @brief Gets the character size being used for serial communication.
          * @return Returns the current character size. 
          */
-        CharacterSize GetCharacterSize();
+        CharacterSize GetCharacterSize() const;
 
         /**
          * @brief Sets flow control for the serial port.
          * @param flowControlType The flow control type to be set.
          */
-        void SetFlowControl(const FlowControl& flowControlType);
+        void SetFlowControl(const FlowControl& flowControlType) const;
 
         /**
          * @brief Gets the current flow control setting.
          * @return Returns the flow control type of the serial port.
          */
-        FlowControl GetFlowControl();
+        FlowControl GetFlowControl() const;
 
         /**
          * @brief Sets the parity type for the serial port.
          * @param parityType The parity type to be set.
          */
-        void SetParity(const Parity& parityType);
+        void SetParity(const Parity& parityType) const;
 
         /**
          * @brief Gets the parity type for the serial port.
          * @return Returns the parity type.
          */
-        Parity GetParity();
+        Parity GetParity() const;
 
         /**
          * @brief Sets the number of stop bits to be used with the serial port.
          * @param stopBits The number of stop bits to set.
          */
-        void SetStopBits(const StopBits& stopBits);
+        void SetStopBits(const StopBits& stopBits) const;
 
         /**
          * @brief Gets the number of stop bits currently being used by the serial
          * @return Returns the number of stop bits.
          */
-        StopBits GetStopBits();
+        StopBits GetStopBits() const;
 
         /**
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @note See VMIN in man termios(3).
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(const short vmin);
+        void SetVMin(const short vmin) const;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -191,71 +192,71 @@ namespace LibSerial
          * @return Returns the minimum number of characters for
          *         non-canonical reads.
          */
-        short GetVMin();
+        short GetVMin() const;
 
         /** 
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds.
          */
-        void SetVTime(const short vtime);
+        void SetVTime(const short vtime) const;
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds. 
          */
-        short GetVTime();
+        short GetVTime() const;
 
         /**
          * @brief Sets the DTR line to the specified value.
          * @param dtrState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetDTR(const bool dtrState = true);
+        void SetDTR(const bool dtrState = true) const;
 
         /**
          * @brief Gets the status of the DTR line.
          * @return Returns true iff the status of the DTR line is high.
          */
-        bool GetDTR();
+        bool GetDTR() const;
 
         /**
          * @brief Set the RTS line to the specified value.
          * @param rtsState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetRTS(const bool rtsState = true);
+        void SetRTS(const bool rtsState = true) const;
 
         /**
          * @brief Get the status of the RTS line.
          * @return Returns true iff the status of the RTS line is high.
          */
-        bool GetRTS();
+        bool GetRTS() const;
 
         /**
          * @brief Get the status of the CTS line.
          * @return Returns true iff the status of the CTS line is high.
          */
-        bool GetCTS();
+        bool GetCTS() const;
 
         /**
          * @brief Get the status of the DSR line.
          * @return Returns true iff the status of the DSR line is high.
          */
-        bool GetDSR();
+        bool GetDSR() const;
 
         /**
          * @brief Gets the serial port file descriptor.
          * @return Returns the serial port file descriptor.
          */
-        int GetFileDescriptor();
+        int GetFileDescriptor() const;
 
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
-        std::vector<std::string> GetAvailableSerialPorts();
+        std::vector<std::string> GetAvailableSerialPorts() const;
 
         /**
          * @brief Reads the specified number of bytes from the serial port.

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -267,44 +267,6 @@ namespace LibSerial
          *        non-zero,  the method will continue receiving data for the
          *        specified of milliseconds. If numberOfBytes is zero and
          *        msTimeout is zero, the method will return immediately. In all
-         *        cases, any data received remains available in the charBuffer
-         *        on return from this method.
-         * @param charBuffer The character array buffer to place data into.
-         * @param numberOfBytes The number of bytes to read before returning.
-         * @param msTimeout The timeout period in milliseconds.
-         */
-        void Read(char*        charBuffer,
-                  const size_t numberOfBytes = 0,
-                  const size_t msTimeout  = 0);
-
-        /**
-         * @brief Reads the specified number of bytes from the serial port.
-         *        The method will timeout if no data is received in the
-         *        specified number of milliseconds (msTimeout). If msTimeout
-         *        is zero, then the method will block until all requested bytes
-         *        are received. If numberOfBytes is zero and msTimeout is
-         *        non-zero,  the method will continue receiving data for the
-         *        specified of milliseconds. If numberOfBytes is zero and
-         *        msTimeout is zero, the method will return immediately. In all
-         *        cases, any data received remains available in the charBuffer
-         *        on return from this method.
-         * @param charBuffer The character array buffer to place data into.
-         * @param numberOfBytes The number of bytes to read before returning.
-         * @param msTimeout The timeout period in milliseconds.
-         */
-        void Read(unsigned char* charBuffer,
-                  const size_t   numberOfBytes = 0,
-                  const size_t   msTimeout  = 0);
-
-        /**
-         * @brief Reads the specified number of bytes from the serial port.
-         *        The method will timeout if no data is received in the
-         *        specified number of milliseconds (msTimeout). If msTimeout
-         *        is zero, then the method will block until all requested bytes
-         *        are received. If numberOfBytes is zero and msTimeout is
-         *        non-zero,  the method will continue receiving data for the
-         *        specified of milliseconds. If numberOfBytes is zero and
-         *        msTimeout is zero, the method will return immediately. In all
          *        cases, any data received remains available in the dataBuffer
          *        on return from this method.
          * @param dataBuffer The data buffer to place data into.
@@ -374,22 +336,6 @@ namespace LibSerial
         void ReadLine(std::string&  dataString,
                       const char    lineTerminator = '\n',
                       const size_t  msTimeout = 0);
-
-        /**
-         * @brief Writes a character array buffer to the serial port.
-         * @param charBuffer The character array to be written to the serial port.
-         * @param numberOfBytes The number of bytes to write to the serial port.
-         */
-        void Write(const char*  charBuffer,
-                   const size_t numberOfBytes);
-
-        /**
-         * @brief Writes a character array buffer to the serial port.
-         * @param charBuffer The character array to be written to the serial port.
-         * @param numberOfBytes The number of bytes to write to the serial port.
-         */
-        void Write(const unsigned char* charBuffer,
-                   const size_t         numberOfBytes);
 
         /**
          * @brief Writes a DataBuffer vector to the serial port.

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -259,13 +259,16 @@ namespace LibSerial
 
         /**
          * @brief Reads the specified number of bytes from the serial port.
-         *        The method will timeout if no data is received in the specified
-         *        number of milliseconds (msTimeout). If msTimeout is 0, then
-         *        this method will block until all requested bytes are
-         *        received. If numberOfBytes is zero, the method will return
-         *        immediately. In all cases, received data remains available
-         *        in the charBuffer on return from this method.
-         * @param charBuffer The character array buffer to place serial data into.
+         *        The method will timeout if no data is received in the
+         *        specified number of milliseconds (msTimeout). If msTimeout
+         *        is zero, then the method will block until all requested bytes
+         *        are received. If numberOfBytes is zero and msTimeout is
+         *        non-zero,  the method will continue receiving data for the
+         *        specified of milliseconds. If numberOfBytes is zero and
+         *        msTimeout is zero, the method will return immediately. In all
+         *        cases, any data received remains available in the charBuffer
+         *        on return from this method.
+         * @param charBuffer The character array buffer to place data into.
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
@@ -275,13 +278,16 @@ namespace LibSerial
 
         /**
          * @brief Reads the specified number of bytes from the serial port.
-         *        The method will timeout if no data is received in the specified
-         *        number of milliseconds (msTimeout). If msTimeout is 0, then
-         *        this method will block until all requested bytes are
-         *        received. If numberOfBytes is zero, the method will return
-         *        immediately. In all cases, received data remains available
-         *        in the charBuffer on return from this method.
-         * @param charBuffer The character array buffer to place serial data into.
+         *        The method will timeout if no data is received in the
+         *        specified number of milliseconds (msTimeout). If msTimeout
+         *        is zero, then the method will block until all requested bytes
+         *        are received. If numberOfBytes is zero and msTimeout is
+         *        non-zero,  the method will continue receiving data for the
+         *        specified of milliseconds. If numberOfBytes is zero and
+         *        msTimeout is zero, the method will return immediately. In all
+         *        cases, any data received remains available in the charBuffer
+         *        on return from this method.
+         * @param charBuffer The character array buffer to place data into.
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
@@ -291,14 +297,16 @@ namespace LibSerial
 
         /**
          * @brief Reads the specified number of bytes from the serial port.
-         *        The method will timeout if no data is received in the specified
-         *        number of milliseconds (msTimeout). If msTimeout is 0, then
-         *        this method will block until all requested bytes are
-         *        received. If numberOfBytes is zero, then this method will keep
-         *        reading data till no more data is available at the serial port.
-         *        In all cases, received data is available in dataBuffer on
-         *        return from this method.
-         * @param dataBuffer The data buffer to place serial data into.
+         *        The method will timeout if no data is received in the
+         *        specified number of milliseconds (msTimeout). If msTimeout
+         *        is zero, then the method will block until all requested bytes
+         *        are received. If numberOfBytes is zero and msTimeout is
+         *        non-zero,  the method will continue receiving data for the
+         *        specified of milliseconds. If numberOfBytes is zero and
+         *        msTimeout is zero, the method will return immediately. In all
+         *        cases, any data received remains available in the dataBuffer
+         *        on return from this method.
+         * @param dataBuffer The data buffer to place data into.
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
@@ -308,14 +316,16 @@ namespace LibSerial
 
         /**
          * @brief Reads the specified number of bytes from the serial port.
-         *        The method will timeout if no data is received in the specified
-         *        number of milliseconds (msTimeout). If msTimeout is 0, then
-         *        this method will block until all requested bytes are
-         *        received. If numberOfBytes is zero, then this method will keep
-         *        reading data till no more data is available at the serial port.
-         *        In all cases, received data is available in dataBuffer on
-         *        return from this method.
-         * @param dataString The data string read from the serial port.
+         *        The method will timeout if no data is received in the
+         *        specified number of milliseconds (msTimeout). If msTimeout
+         *        is zero, then the method will block until all requested bytes
+         *        are received. If numberOfBytes is zero and msTimeout is
+         *        non-zero,  the method will continue receiving data for the
+         *        specified of milliseconds. If numberOfBytes is zero and
+         *        msTimeout is zero, the method will return immediately. In all
+         *        cases, any data received remains available in the dataString
+         *        on return from this method.
+         * @param dataString The string to place data into.
          * @param numberOfBytes The number of bytes to read before returning.
          * @param msTimeout The timeout period in milliseconds.
          */
@@ -324,11 +334,11 @@ namespace LibSerial
                   const size_t msTimeout  = 0);
 
         /**
-         * @brief Reads a single byte from the serial port.
-         *        If no data is available within the specified number
-         *        of milliseconds (msTimeout), then this method will
-         *        throw a ReadTimeout exception. If msTimeout is 0,
-         *        then this method will block until data is available.
+         * @brief Reads a single byte from the serial port. If no data is 
+         *        available within the specified number of milliseconds,
+         *        (msTimeout), then this method will throw a ReadTimeout
+         *        exception. If msTimeout is zero, then this method will
+         *        block until data becomes available.
          * @param charBuffer The character read from the serial port.
          * @param msTimeout The timeout period in milliseconds.
          */
@@ -336,11 +346,11 @@ namespace LibSerial
                       const size_t msTimeout = 0);
 
         /**
-         * @brief Reads a single byte from the serial port.
-         *        If no data is available within the specified number
-         *        of milliseconds (msTimeout), then this method will
-         *        throw a ReadTimeout exception. If msTimeout is 0,
-         *        then this method will block until data is available.
+         * @brief Reads a single byte from the serial port. If no data is 
+         *        available within the specified number of milliseconds,
+         *        (msTimeout), then this method will throw a ReadTimeout
+         *        exception. If msTimeout is zero, then this method will
+         *        block until data becomes available.
          * @param charBuffer The character read from the serial port.
          * @param msTimeout The timeout period in milliseconds.
          */
@@ -349,12 +359,11 @@ namespace LibSerial
 
         /**
          * @brief Reads a line of characters from the serial port.
-         *        The method will timeout if no data is received in the specified
-         *        number of milliseconds (msTimeout). If msTimeout is 0, then
-         *        this method will block until a line terminator is received.
-         *        If a line terminator is read, a string will be returned,
-         *        however, if the timeout is reached, an exception will be thrown
-         *        and all previously read data will be lost.
+         *        The method will timeout if no data is received in the
+         *        specified number of milliseconds (msTimeout).
+         *        If msTimeout is 0, then this method will block until a line
+         *        terminator is received. In all cases, any data received
+         *        remains available in the string on return from this method.
          * @param dataString The data string read from the serial port.
          * @param lineTerminator The line termination character to specify the
          *        end of a line.

--- a/src/SerialPortConstants.h
+++ b/src/SerialPortConstants.h
@@ -58,7 +58,7 @@ namespace LibSerial
      * @brief The default character buffer timing.
      */
     static constexpr short VTIME_DEFAULT = 0;
-    
+
     /**
      * @brief Character used to signal that I/O can start while using
      *        software flow control with the serial port.
@@ -70,12 +70,12 @@ namespace LibSerial
      *        software flow control with the serial port.
      */
     static constexpr char CTRL_S = 0x13;
-    
+
     /**
      * @brief Type used to receive and return raw data to/from methods.
      */
     typedef std::vector<unsigned char> DataBuffer;
-    
+
 
     /**
      * @note - For reference, below is a list of std::exception types:

--- a/src/SerialStream.cpp
+++ b/src/SerialStream.cpp
@@ -93,6 +93,32 @@ SerialStream::Close()
 }
 
 void
+SerialStream::DrainWriteBuffer()
+{
+    SerialStreamBuf* my_buffer = dynamic_cast<SerialStreamBuf *>(this->rdbuf());
+
+    // Make sure that we are dealing with a SerialStreamBuf before
+    // proceeding. This check also makes sure that we have a non-NULL
+    // buffer associated with this stream.
+    if (my_buffer)
+    {
+        // Try to flush the input buffers the serial port with the correspoding
+        // function of the SerialStreamBuf class.
+        my_buffer->DrainWriteBuffer();
+    }
+    else
+    {
+        // If the dynamic_cast above failed then we either have a NULL
+        // streambuf associated with this stream or we have a buffer
+        // of class other than SerialStreamBuf. In either case, we
+        // have a problem and we should stop all I/O using this stream.
+        setstate(badbit);
+    }
+
+    return;
+}
+
+void
 SerialStream::FlushInputBuffer()
 {
     SerialStreamBuf* my_buffer = dynamic_cast<SerialStreamBuf *>(this->rdbuf());

--- a/src/SerialStream.cpp
+++ b/src/SerialStream.cpp
@@ -171,19 +171,6 @@ SerialStream::FlushIOBuffers()
 }
 
 bool
-SerialStream::IsOpen()
-{
-    // Checks to see if mIOBuffer is a null buffer, if not, calls
-    // the IsOpen() function on this stream's SerialStreamBuf mIOBuffer
-    if (!mIOBuffer)
-    {
-        return false;
-    }
-
-    return mIOBuffer->IsOpen();
-}
-
-bool
 SerialStream::IsDataAvailable()
 {
     SerialStreamBuf* my_buffer = dynamic_cast<SerialStreamBuf *>(this->rdbuf());
@@ -206,6 +193,19 @@ SerialStream::IsDataAvailable()
         setstate(badbit);
         return false;
     }
+}
+
+bool
+SerialStream::IsOpen()
+{
+    // Checks to see if mIOBuffer is a null buffer, if not, calls
+    // the IsOpen() function on this stream's SerialStreamBuf mIOBuffer
+    if (!mIOBuffer)
+    {
+        return false;
+    }
+
+    return mIOBuffer->IsOpen();
 }
 
 void 
@@ -287,7 +287,7 @@ SerialStream::SetCharacterSize(const CharacterSize& characterSize)
 }
 
 CharacterSize
-SerialStream::GetCharacterSize() 
+SerialStream::GetCharacterSize()
 {
     SerialStreamBuf* my_buffer = dynamic_cast<SerialStreamBuf *>(this->rdbuf());
 

--- a/src/SerialStream.cpp
+++ b/src/SerialStream.cpp
@@ -766,6 +766,31 @@ SerialStream::GetFileDescriptor()
     }
 }
 
+int
+SerialStream::GetNumberOfBytesAvailable()
+{
+    SerialStreamBuf* my_buffer = dynamic_cast<SerialStreamBuf *>(this->rdbuf());
+
+    // Make sure that we are dealing with a SerialStreamBuf before
+    // proceeding. This check also makes sure that we have a non-NULL
+    // buffer associated with this stream.
+    if (my_buffer)
+    {
+        // Try to determine if data is available with the correspoding
+        // function of the SerialStreamBuf class.
+        return my_buffer->GetNumberOfBytesAvailable();
+    }
+    else
+    {
+        // If the dynamic_cast above failed then we either have a NULL
+        // streambuf associated with this stream or we have a buffer
+        // of class other than SerialStreamBuf. In either case, we
+        // have a problem and we should stop all I/O using this stream.
+        setstate(badbit);
+        return false;
+    }
+}
+
 std::vector<std::string>
 SerialStream::GetAvailableSerialPorts()
 {

--- a/src/SerialStream.h
+++ b/src/SerialStream.h
@@ -91,8 +91,9 @@ namespace LibSerial
                               const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT);
 
         /**
-         * @brief Default Destructor.
-         *        Closes the stream associated with mFileDescriptor.
+         * @brief Default Destructor for a SerialStream object
+         *        Closes the stream associated with mFileDescriptor, and
+         *        also closes the serial port if open.
          *        Remaining actions are accomplished by the fstream destructor.
          */
         virtual ~SerialStream(); 

--- a/src/SerialStream.h
+++ b/src/SerialStream.h
@@ -284,6 +284,12 @@ namespace LibSerial
         int GetFileDescriptor();
 
         /**
+         * @brief Gets the number of bytes available in the read buffer.
+         * @return Returns the number of bytes avilable in the read buffer.
+         */
+        int GetNumberOfBytesAvailable();
+
+        /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 

--- a/src/SerialStream.h
+++ b/src/SerialStream.h
@@ -101,7 +101,7 @@ namespace LibSerial
         /**
          * @brief Opens the serial port associated with the specified
          *        file name and the specified mode.
-         * @param fileName The file name of the serial port object.
+         * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
          */

--- a/src/SerialStream.h
+++ b/src/SerialStream.h
@@ -115,6 +115,11 @@ namespace LibSerial
         void Close();
 
         /**
+         * @brief Waits until the write buffer is drained and then returns.
+         */
+        void DrainWriteBuffer();
+
+        /**
          * @brief Flushes the serial port input buffer.
          */
         void FlushInputBuffer();

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -68,7 +68,7 @@ namespace LibSerial
         /**
          * @brief Opens the serial port associated with the specified
          *        file name and the specified mode.
-         * @param fileName The file name of the serial port object.
+         * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
          */

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -908,7 +908,7 @@ namespace LibSerial
     }
 
     inline
-    void 
+    void
     SerialStreamBuf::Implementation::SetDefaultSerialPortParameters()
     {
         // Make sure that the serial port is open.
@@ -1374,7 +1374,7 @@ namespace LibSerial
     }
 
     inline
-    void 
+    void
     SerialStreamBuf::Implementation::SetVMin(const short vmin)
     {
         // Throw an exception if the serial port is not open.
@@ -1412,7 +1412,7 @@ namespace LibSerial
     }
 
     inline
-    short 
+    short
     SerialStreamBuf::Implementation::GetVMin()
     {
         // Throw an exception if the serial port is not open.
@@ -1435,7 +1435,7 @@ namespace LibSerial
     }
 
     inline
-    void 
+    void
     SerialStreamBuf::Implementation::SetVTime(const short vtime)
     {
         // Throw an exception if the serial port is not open.
@@ -1473,7 +1473,7 @@ namespace LibSerial
     }
 
     inline
-    short 
+    short
     SerialStreamBuf::Implementation::GetVTime()
     {
         // Throw an exception if the serial port is not open.

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -82,6 +82,11 @@ namespace LibSerial
         void Close();
 
         /**
+         * @brief Waits until the write buffer is drained and then returns.
+         */
+        void DrainWriteBuffer();
+
+        /**
          * @brief Flushes the serial port input buffer.
          */
         void FlushInputBuffer();
@@ -445,6 +450,13 @@ namespace LibSerial
     SerialStreamBuf::Close()
     {
         mImpl->Close();
+        return;
+    }
+
+    void
+    SerialStreamBuf::DrainWriteBuffer()
+    {
+        mImpl->DrainWriteBuffer();
         return;
     }
 
@@ -817,6 +829,24 @@ namespace LibSerial
 
         // Set the file descriptor to an invalid value, -1. 
         mFileDescriptor = -1;
+        return;
+    }
+
+    inline
+    void
+    SerialStreamBuf::Implementation::DrainWriteBuffer()
+    {
+        // Throw an exception if the serial port is not open.
+        if (!this->IsOpen())
+        {
+            throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
+        }
+
+        if (tcdrain(this->mFileDescriptor) < 0)
+        {
+            throw std::runtime_error(std::strerror(errno));
+        }
+
         return;
     }
 

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -60,7 +60,8 @@ namespace LibSerial
                        const StopBits&      stopBits);
 
         /**
-         * @brief Default Destructor.
+         * @brief Default Destructor for a SerialStreamBuf object. Closes the
+         *        serial port associated with mFileDescriptor if open.
          */
         ~Implementation();
 
@@ -83,167 +84,167 @@ namespace LibSerial
         /**
          * @brief Flushes the serial port input buffer.
          */
-        void FlushInputBuffer();
+        void FlushInputBuffer() const;
 
         /**
          * @brief Flushes the serial port output buffer.
          */
-        void FlushOutputBuffer();
+        void FlushOutputBuffer() const;
 
         /**
          * @brief Flushes the serial port input and output buffers.
          */
-        void FlushIOBuffers();
+        void FlushIOBuffers() const;
 
         /**
          * @brief Determines if data is available at the serial port.
          */
-        bool IsDataAvailable();
+        bool IsDataAvailable() const;
 
         /**
          * @brief Determines if the serial port is open for I/O.
          * @return Returns true iff the serial port is open.
          */
-        bool IsOpen();
+        bool IsOpen() const;
 
         /**
          * @brief Sets all serial port paramters to their default values.
          */
-        void SetDefaultSerialPortParameters();
+        void SetDefaultSerialPortParameters() const;
 
         /**
          * @brief Sets the baud rate for the serial port to the specified value
          * @param baudRate The baud rate to be set for the serial port.
          */
-        void SetBaudRate(const BaudRate& baudRate);
+        void SetBaudRate(const BaudRate& baudRate) const;
 
         /**
          * @brief Gets the current baud rate for the serial port.
          * @return Returns the baud rate.
          */
-        BaudRate GetBaudRate();
+        BaudRate GetBaudRate() const;
 
         /**
          * @brief Sets the character size for the serial port.
          * @param characterSize The character size to be set.
          */
-        void SetCharacterSize(const CharacterSize& characterSize);
+        void SetCharacterSize(const CharacterSize& characterSize) const;
 
         /**
          * @brief Gets the character size being used for serial communication.
          * @return Returns the current character size. 
          */
-        CharacterSize GetCharacterSize();
+        CharacterSize GetCharacterSize() const;
 
         /**
          * @brief Sets flow control for the serial port.
          * @param flowControlType The flow control type to be set.
          */
-        void SetFlowControl(const FlowControl& flowControlType);
+        void SetFlowControl(const FlowControl& flowControlType) const;
 
         /**
          * @brief Get the current flow control setting.
          * @return Returns the flow control type of the serial port.
          */
-        FlowControl GetFlowControl();
+        FlowControl GetFlowControl() const;
 
         /**
          * @brief Sets the parity type for the serial port.
          * @param parityType The parity type to be set.
          */
-        void SetParity(const Parity& parityType);
+        void SetParity(const Parity& parityType) const;
 
         /**
          * @brief Gets the parity type for the serial port.
          * @return Returns the parity type.
          */
-        Parity GetParity();
+        Parity GetParity() const;
 
         /**
          * @brief Sets the number of stop bits to be used with the serial port.
          * @param stopBits The number of stop bits to set.
          */
-        void SetStopBits(const StopBits& stopBits);
+        void SetStopBits(const StopBits& stopBits) const;
 
         /**
          * @brief Gets the number of stop bits currently being used by the serial
          * @return Returns the number of stop bits.
          */
-        StopBits GetStopBits();
+        StopBits GetStopBits() const;
 
         /**
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(const short vmin);
+        void SetVMin(const short vmin) const;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
          *        minimum number of characters for non-canonical reads.
          * @return Returns the minimum number of characters for non-canonical reads.
          */
-        short GetVMin();
+        short GetVMin() const;
 
         /** 
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          */
-        void SetVTime(const short vtime);
+        void SetVTime(const short vtime) const;
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds. 
          */
-        short GetVTime();
+        short GetVTime() const;
 
         /**
          * @brief Sets the serial port DTR line status.
          * @param dtrState The state to set the DTR line
          */
-        void SetDTR(const bool dtrState);
+        void SetDTR(const bool dtrState) const;
 
         /**
          * @brief Gets the serial port DTR line status.
          * @return Returns true iff the status of the DTR line is high.
          */
-        bool GetDTR();
+        bool GetDTR() const;
 
         /**
          * @brief Sets the serial port RTS line status.
          * @param rtsState The state to set the RTS line
          */
-        void SetRTS(const bool rtsState);
+        void SetRTS(const bool rtsState) const;
 
         /**
          * @brief Gets the serial port RTS line status.
          * @return Returns true iff the status of the RTS line is high.
          */
-        bool GetRTS();
+        bool GetRTS() const;
 
         /**
          * @brief Gets the serial port CTS line status.
          * @return Returns true iff the status of the CTS line is high.
          */
-        bool GetCTS();
+        bool GetCTS() const;
 
         /**
          * @brief Gets the serial port DSR line status.
          * @return Returns true iff the status of the DSR line is high.
          */
-        bool GetDSR();
+        bool GetDSR() const;
 
         /**
          * @brief Gets the serial port file descriptor.
          * @return Returns the serial port file descriptor.
          */
-        int GetFileDescriptor();
+        int GetFileDescriptor() const;
 
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
-        std::vector<std::string> GetAvailableSerialPorts();
+        std::vector<std::string> GetAvailableSerialPorts() const;
 
         /**
          * @brief Writes up to n characters from the character sequence at 
@@ -322,7 +323,7 @@ namespace LibSerial
         char mPutbackChar;
 
     protected:
-        
+
     private:
 
         /**
@@ -333,7 +334,7 @@ namespace LibSerial
          *        call to this method.
          */
         void SetModemControlLine(const int modemLine,
-                                 const bool lineState);
+                                 const bool lineState) const;
 
         /**
          * @brief Get the current state of the specified modem control line.
@@ -342,45 +343,46 @@ namespace LibSerial
          * @return True if the specified line is currently set and false
          *         otherwise.
          */
-        bool GetModemControlLine(const int modemLine);
+        bool GetModemControlLine(const int modemLine) const;
 
         /**
          * @brief Sets the current state of the serial port blocking status.
          * @param blockingStatus The serial port blocking status to be set,
          *        true if to be set blocking, false if to be set non-blocking.
          */
-        void SetSerialPortBlockingStatus(const bool blockingStatus);
+        void SetSerialPortBlockingStatus(const bool blockingStatus) const;
 
         /**
          * @brief Gets the current state of the serial port blocking status.
          * @return True if port is blocking, false if port non-blocking.
          */
-        bool GetSerialPortBlockingStatus();
+        bool GetSerialPortBlockingStatus() const;
 
         /**
          * @brief Sets the default Linux specific line discipline modes.
          */
-        void SetDefaultLinuxSpecificModes();
+        void SetDefaultLinuxSpecificModes() const;
 
         /**
          * @brief Sets the default serial port input modes.
          */
-        void SetDefaultInputModes();
+        void SetDefaultInputModes() const;
 
         /**
          * @brief Sets the default serial port output modes.
          */
-        void SetDefaultOutputModes();
+        void SetDefaultOutputModes() const;
 
         /**
          * @brief Sets the default serial port control modes.
          */
-        void SetDefaultControlModes();
+        void SetDefaultControlModes() const;
 
         /**
          * @brief Sets the default serial port local modes.
          */
-        void SetDefaultLocalModes();
+        void SetDefaultLocalModes() const;
+
 
         /**
          * @brief The file descriptor corresponding to the serial port.
@@ -447,182 +449,182 @@ namespace LibSerial
     }
 
     void
-    SerialStreamBuf::FlushInputBuffer()
+    SerialStreamBuf::FlushInputBuffer() const
     {
         mImpl->FlushInputBuffer();
         return;
     }
 
     void
-    SerialStreamBuf::FlushOutputBuffer()
+    SerialStreamBuf::FlushOutputBuffer() const
     {
         mImpl->FlushOutputBuffer();
         return;
     }
 
     void
-    SerialStreamBuf::FlushIOBuffers()
+    SerialStreamBuf::FlushIOBuffers() const
     {
         mImpl->FlushIOBuffers();
         return;
     }
 
     bool
-    SerialStreamBuf::IsDataAvailable()
+    SerialStreamBuf::IsDataAvailable() const
     {
         return mImpl->IsDataAvailable();
     }
 
     bool
-    SerialStreamBuf::IsOpen()
+    SerialStreamBuf::IsOpen() const
     {
         return mImpl->IsOpen();
     }
 
     void
-    SerialStreamBuf::SetDefaultSerialPortParameters()
+    SerialStreamBuf::SetDefaultSerialPortParameters() const
     {
         mImpl->SetDefaultSerialPortParameters();
         return;
     }
 
     void
-    SerialStreamBuf::SetBaudRate(const BaudRate& baudRate)
+    SerialStreamBuf::SetBaudRate(const BaudRate& baudRate) const
     {
         mImpl->SetBaudRate(baudRate);
         return;
     }
 
     BaudRate
-    SerialStreamBuf::GetBaudRate()
+    SerialStreamBuf::GetBaudRate() const
     {
         return mImpl->GetBaudRate();
     }
 
     void
-    SerialStreamBuf::SetCharacterSize(const CharacterSize& characterSize)
+    SerialStreamBuf::SetCharacterSize(const CharacterSize& characterSize) const
     {
         mImpl->SetCharacterSize(characterSize);
         return;
     }
 
     CharacterSize
-    SerialStreamBuf::GetCharacterSize()
+    SerialStreamBuf::GetCharacterSize() const
     {
         return mImpl->GetCharacterSize();
     }
 
     void
-    SerialStreamBuf::SetFlowControl(const FlowControl& flowControlType)
+    SerialStreamBuf::SetFlowControl(const FlowControl& flowControlType) const
     {
         mImpl->SetFlowControl(flowControlType);
         return;
     }
 
     FlowControl
-    SerialStreamBuf::GetFlowControl()
+    SerialStreamBuf::GetFlowControl() const
     {
         return mImpl->GetFlowControl();
     }
 
     void
-    SerialStreamBuf::SetParity(const Parity& parityType)
+    SerialStreamBuf::SetParity(const Parity& parityType) const
     {
         mImpl->SetParity(parityType);
         return;
     }
 
     Parity
-    SerialStreamBuf::GetParity()
+    SerialStreamBuf::GetParity() const
     {
         return mImpl->GetParity();
     }
 
     void
-    SerialStreamBuf::SetStopBits(const StopBits& stopBits)
+    SerialStreamBuf::SetStopBits(const StopBits& stopBits) const
     {
         mImpl->SetStopBits(stopBits);
         return;
     }
 
     StopBits
-    SerialStreamBuf::GetStopBits()
+    SerialStreamBuf::GetStopBits() const
     {
         return mImpl->GetStopBits();
     }
 
     void
-    SerialStreamBuf::SetVMin(const short vmin)
+    SerialStreamBuf::SetVMin(const short vmin) const
     {
         mImpl->SetVMin(vmin);
         return;
     }
 
     short
-    SerialStreamBuf::GetVMin()
+    SerialStreamBuf::GetVMin() const
     {
         return mImpl->GetVMin();
     }
 
     void
-    SerialStreamBuf::SetVTime(const short vtime)
+    SerialStreamBuf::SetVTime(const short vtime) const
     {
         mImpl->SetVTime(vtime);
         return;
     }
 
     short
-    SerialStreamBuf::GetVTime()
+    SerialStreamBuf::GetVTime() const
     {
         return mImpl->GetVTime();
     }
 
     void
-    SerialStreamBuf::SetDTR(const bool dtrState)
+    SerialStreamBuf::SetDTR(const bool dtrState) const
     {
         mImpl->SetDTR(dtrState);
         return;
     }
 
     bool
-    SerialStreamBuf::GetDTR()
+    SerialStreamBuf::GetDTR() const
     {
         return mImpl->GetDTR();
     }
 
     void
-    SerialStreamBuf::SetRTS(const bool rtsState)
+    SerialStreamBuf::SetRTS(const bool rtsState) const
     {
         mImpl->SetRTS(rtsState);
         return;
     }
 
     bool
-    SerialStreamBuf::GetRTS()
+    SerialStreamBuf::GetRTS() const
     {
         return mImpl->GetRTS();
     }
 
     bool
-    SerialStreamBuf::GetCTS()
+    SerialStreamBuf::GetCTS() const
     {
         return mImpl->GetCTS();
     }
 
     bool
-    SerialStreamBuf::GetDSR() 
+    SerialStreamBuf::GetDSR()  const
     {
         return mImpl->GetDSR();
     }
 
     int
-    SerialStreamBuf::GetFileDescriptor()
+    SerialStreamBuf::GetFileDescriptor() const
     {
         return mImpl->GetFileDescriptor();
     }
 
     std::vector<std::string>
-    SerialStreamBuf::GetAvailableSerialPorts()
+    SerialStreamBuf::GetAvailableSerialPorts() const
     {
         return mImpl->GetAvailableSerialPorts();
     }
@@ -820,7 +822,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::FlushInputBuffer()
+    SerialStreamBuf::Implementation::FlushInputBuffer() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -838,7 +840,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::FlushOutputBuffer()
+    SerialStreamBuf::Implementation::FlushOutputBuffer() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -856,7 +858,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::FlushIOBuffers()
+    SerialStreamBuf::Implementation::FlushIOBuffers() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -874,14 +876,14 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::IsOpen()
+    SerialStreamBuf::Implementation::IsOpen() const
     {
         return (this->mFileDescriptor != -1);
     }
 
     inline
     bool
-    SerialStreamBuf::Implementation::IsDataAvailable()
+    SerialStreamBuf::Implementation::IsDataAvailable() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -907,7 +909,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialStreamBuf::Implementation::SetDefaultSerialPortParameters()
+    SerialStreamBuf::Implementation::SetDefaultSerialPortParameters() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -937,7 +939,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetBaudRate(const BaudRate& baudRate)
+    SerialStreamBuf::Implementation::SetBaudRate(const BaudRate& baudRate) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -976,7 +978,7 @@ namespace LibSerial
 
     inline
     BaudRate
-    SerialStreamBuf::Implementation::GetBaudRate()
+    SerialStreamBuf::Implementation::GetBaudRate() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1012,7 +1014,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetCharacterSize(const CharacterSize& characterSize)
+    SerialStreamBuf::Implementation::SetCharacterSize(const CharacterSize& characterSize) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1064,7 +1066,7 @@ namespace LibSerial
 
     inline
     CharacterSize
-    SerialStreamBuf::Implementation::GetCharacterSize()
+    SerialStreamBuf::Implementation::GetCharacterSize() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1088,7 +1090,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetFlowControl(const FlowControl& flowControlType)
+    SerialStreamBuf::Implementation::SetFlowControl(const FlowControl& flowControlType) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1152,7 +1154,7 @@ namespace LibSerial
 
     inline
     FlowControl
-    SerialStreamBuf::Implementation::GetFlowControl()
+    SerialStreamBuf::Implementation::GetFlowControl() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1202,7 +1204,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetParity(const Parity& parityType)
+    SerialStreamBuf::Implementation::SetParity(const Parity& parityType) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1255,7 +1257,7 @@ namespace LibSerial
 
     inline
     Parity
-    SerialStreamBuf::Implementation::GetParity()
+    SerialStreamBuf::Implementation::GetParity() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1296,7 +1298,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetStopBits(const StopBits& stopBits)
+    SerialStreamBuf::Implementation::SetStopBits(const StopBits& stopBits) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1341,7 +1343,7 @@ namespace LibSerial
 
     inline
     StopBits
-    SerialStreamBuf::Implementation::GetStopBits()
+    SerialStreamBuf::Implementation::GetStopBits() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1373,7 +1375,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialStreamBuf::Implementation::SetVMin(const short vmin)
+    SerialStreamBuf::Implementation::SetVMin(const short vmin) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1411,7 +1413,7 @@ namespace LibSerial
 
     inline
     short 
-    SerialStreamBuf::Implementation::GetVMin()
+    SerialStreamBuf::Implementation::GetVMin() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1434,7 +1436,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialStreamBuf::Implementation::SetVTime(const short vtime)
+    SerialStreamBuf::Implementation::SetVTime(const short vtime) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1472,7 +1474,7 @@ namespace LibSerial
 
     inline
     short 
-    SerialStreamBuf::Implementation::GetVTime() 
+    SerialStreamBuf::Implementation::GetVTime() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1495,7 +1497,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDTR(const bool dtrState)
+    SerialStreamBuf::Implementation::SetDTR(const bool dtrState) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1510,7 +1512,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetDTR()
+    SerialStreamBuf::Implementation::GetDTR() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1523,7 +1525,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetRTS(const bool rtsState)
+    SerialStreamBuf::Implementation::SetRTS(const bool rtsState) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1538,7 +1540,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetRTS()
+    SerialStreamBuf::Implementation::GetRTS() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1551,7 +1553,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetCTS()
+    SerialStreamBuf::Implementation::GetCTS() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1564,7 +1566,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetDSR()
+    SerialStreamBuf::Implementation::GetDSR() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1577,7 +1579,7 @@ namespace LibSerial
 
     inline
     int
-    SerialStreamBuf::Implementation::GetFileDescriptor()
+    SerialStreamBuf::Implementation::GetFileDescriptor() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1590,7 +1592,7 @@ namespace LibSerial
 
     inline
     std::vector<std::string>
-    SerialStreamBuf::Implementation::GetAvailableSerialPorts()
+    SerialStreamBuf::Implementation::GetAvailableSerialPorts() const
     {
         const int array_size = 3;
         int file_descriptor = -1;
@@ -1639,7 +1641,7 @@ namespace LibSerial
     inline
     void
     SerialStreamBuf::Implementation::SetModemControlLine(const int  modemLine,
-                                                         const bool lineState)
+                                                         const bool lineState) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1691,7 +1693,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetModemControlLine(const int modemLine)
+    SerialStreamBuf::Implementation::GetModemControlLine(const int modemLine) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1729,7 +1731,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetSerialPortBlockingStatus(const bool blockingStatus)
+    SerialStreamBuf::Implementation::SetSerialPortBlockingStatus(const bool blockingStatus) const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1761,7 +1763,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetSerialPortBlockingStatus()
+    SerialStreamBuf::Implementation::GetSerialPortBlockingStatus() const
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1787,7 +1789,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultLinuxSpecificModes()
+    SerialStreamBuf::Implementation::SetDefaultLinuxSpecificModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1822,7 +1824,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultInputModes()
+    SerialStreamBuf::Implementation::SetDefaultInputModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1856,7 +1858,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultOutputModes()
+    SerialStreamBuf::Implementation::SetDefaultOutputModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1889,7 +1891,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultControlModes()
+    SerialStreamBuf::Implementation::SetDefaultControlModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1923,7 +1925,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultLocalModes()
+    SerialStreamBuf::Implementation::SetDefaultLocalModes() const
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1957,7 +1959,7 @@ namespace LibSerial
     inline
     std::streamsize
     SerialStreamBuf::Implementation::xsputn(const char_type* character,
-                                            std::streamsize numberOfBytes) 
+                                            std::streamsize numberOfBytes)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -2156,7 +2158,7 @@ namespace LibSerial
 
     inline
     std::streambuf::int_type
-    SerialStreamBuf::Implementation::pbackfail(const int_type character) 
+    SerialStreamBuf::Implementation::pbackfail(const int_type character)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -245,6 +245,12 @@ namespace LibSerial
         int GetFileDescriptor();
 
         /**
+         * @brief Gets the number of bytes available in the read buffer.
+         * @return Returns the number of bytes avilable in the read buffer.
+         */
+        int GetNumberOfBytesAvailable();
+
+        /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
@@ -635,12 +641,17 @@ namespace LibSerial
         return mImpl->GetFileDescriptor();
     }
 
+    int
+    SerialStreamBuf::GetNumberOfBytesAvailable()
+    {
+        return mImpl->GetNumberOfBytesAvailable();
+    }
+
     std::vector<std::string>
     SerialStreamBuf::GetAvailableSerialPorts()
     {
         return mImpl->GetAvailableSerialPorts();
     }
-
 
     std::streambuf*
     SerialStreamBuf::setbuf(char_type* character, std::streamsize numberOfBytes)
@@ -1618,6 +1629,28 @@ namespace LibSerial
         }
 
         return this->mFileDescriptor;
+    }
+
+    inline
+    int
+    SerialStreamBuf::Implementation::GetNumberOfBytesAvailable()
+    {
+        // Throw an exception if the serial port is not open.
+        if (!this->IsOpen())
+        {
+            throw NotOpen(ERR_MSG_PORT_NOT_OPEN);
+        }
+
+        int number_of_bytes_available = 0;
+
+        if (ioctl(this->mFileDescriptor,
+                  FIONREAD,
+                  &number_of_bytes_available) < 0)
+        {
+            throw std::runtime_error(std::strerror(errno));
+        }
+
+        return number_of_bytes_available;
     }
 
     inline

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -84,167 +84,167 @@ namespace LibSerial
         /**
          * @brief Flushes the serial port input buffer.
          */
-        void FlushInputBuffer() const;
+        void FlushInputBuffer();
 
         /**
          * @brief Flushes the serial port output buffer.
          */
-        void FlushOutputBuffer() const;
+        void FlushOutputBuffer();
 
         /**
          * @brief Flushes the serial port input and output buffers.
          */
-        void FlushIOBuffers() const;
+        void FlushIOBuffers();
 
         /**
          * @brief Determines if data is available at the serial port.
          */
-        bool IsDataAvailable() const;
+        bool IsDataAvailable();
 
         /**
          * @brief Determines if the serial port is open for I/O.
          * @return Returns true iff the serial port is open.
          */
-        bool IsOpen() const;
+        bool IsOpen();
 
         /**
          * @brief Sets all serial port paramters to their default values.
          */
-        void SetDefaultSerialPortParameters() const;
+        void SetDefaultSerialPortParameters();
 
         /**
          * @brief Sets the baud rate for the serial port to the specified value
          * @param baudRate The baud rate to be set for the serial port.
          */
-        void SetBaudRate(const BaudRate& baudRate) const;
+        void SetBaudRate(const BaudRate& baudRate);
 
         /**
          * @brief Gets the current baud rate for the serial port.
          * @return Returns the baud rate.
          */
-        BaudRate GetBaudRate() const;
+        BaudRate GetBaudRate();
 
         /**
          * @brief Sets the character size for the serial port.
          * @param characterSize The character size to be set.
          */
-        void SetCharacterSize(const CharacterSize& characterSize) const;
+        void SetCharacterSize(const CharacterSize& characterSize);
 
         /**
          * @brief Gets the character size being used for serial communication.
          * @return Returns the current character size. 
          */
-        CharacterSize GetCharacterSize() const;
+        CharacterSize GetCharacterSize();
 
         /**
          * @brief Sets flow control for the serial port.
          * @param flowControlType The flow control type to be set.
          */
-        void SetFlowControl(const FlowControl& flowControlType) const;
+        void SetFlowControl(const FlowControl& flowControlType);
 
         /**
          * @brief Get the current flow control setting.
          * @return Returns the flow control type of the serial port.
          */
-        FlowControl GetFlowControl() const;
+        FlowControl GetFlowControl();
 
         /**
          * @brief Sets the parity type for the serial port.
          * @param parityType The parity type to be set.
          */
-        void SetParity(const Parity& parityType) const;
+        void SetParity(const Parity& parityType);
 
         /**
          * @brief Gets the parity type for the serial port.
          * @return Returns the parity type.
          */
-        Parity GetParity() const;
+        Parity GetParity();
 
         /**
          * @brief Sets the number of stop bits to be used with the serial port.
          * @param stopBits The number of stop bits to set.
          */
-        void SetStopBits(const StopBits& stopBits) const;
+        void SetStopBits(const StopBits& stopBits);
 
         /**
          * @brief Gets the number of stop bits currently being used by the serial
          * @return Returns the number of stop bits.
          */
-        StopBits GetStopBits() const;
+        StopBits GetStopBits();
 
         /**
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(const short vmin) const;
+        void SetVMin(const short vmin);
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
          *        minimum number of characters for non-canonical reads.
          * @return Returns the minimum number of characters for non-canonical reads.
          */
-        short GetVMin() const;
+        short GetVMin();
 
         /** 
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          */
-        void SetVTime(const short vtime) const;
+        void SetVTime(const short vtime);
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds. 
          */
-        short GetVTime() const;
+        short GetVTime();
 
         /**
          * @brief Sets the serial port DTR line status.
          * @param dtrState The state to set the DTR line
          */
-        void SetDTR(const bool dtrState) const;
+        void SetDTR(const bool dtrState);
 
         /**
          * @brief Gets the serial port DTR line status.
          * @return Returns true iff the status of the DTR line is high.
          */
-        bool GetDTR() const;
+        bool GetDTR();
 
         /**
          * @brief Sets the serial port RTS line status.
          * @param rtsState The state to set the RTS line
          */
-        void SetRTS(const bool rtsState) const;
+        void SetRTS(const bool rtsState);
 
         /**
          * @brief Gets the serial port RTS line status.
          * @return Returns true iff the status of the RTS line is high.
          */
-        bool GetRTS() const;
+        bool GetRTS();
 
         /**
          * @brief Gets the serial port CTS line status.
          * @return Returns true iff the status of the CTS line is high.
          */
-        bool GetCTS() const;
+        bool GetCTS();
 
         /**
          * @brief Gets the serial port DSR line status.
          * @return Returns true iff the status of the DSR line is high.
          */
-        bool GetDSR() const;
+        bool GetDSR();
 
         /**
          * @brief Gets the serial port file descriptor.
          * @return Returns the serial port file descriptor.
          */
-        int GetFileDescriptor() const;
+        int GetFileDescriptor();
 
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
-        std::vector<std::string> GetAvailableSerialPorts() const;
+        std::vector<std::string> GetAvailableSerialPorts();
 
         /**
          * @brief Writes up to n characters from the character sequence at 
@@ -334,7 +334,7 @@ namespace LibSerial
          *        call to this method.
          */
         void SetModemControlLine(const int modemLine,
-                                 const bool lineState) const;
+                                 const bool lineState);
 
         /**
          * @brief Get the current state of the specified modem control line.
@@ -343,45 +343,45 @@ namespace LibSerial
          * @return True if the specified line is currently set and false
          *         otherwise.
          */
-        bool GetModemControlLine(const int modemLine) const;
+        bool GetModemControlLine(const int modemLine);
 
         /**
          * @brief Sets the current state of the serial port blocking status.
          * @param blockingStatus The serial port blocking status to be set,
          *        true if to be set blocking, false if to be set non-blocking.
          */
-        void SetSerialPortBlockingStatus(const bool blockingStatus) const;
+        void SetSerialPortBlockingStatus(const bool blockingStatus);
 
         /**
          * @brief Gets the current state of the serial port blocking status.
          * @return True if port is blocking, false if port non-blocking.
          */
-        bool GetSerialPortBlockingStatus() const;
+        bool GetSerialPortBlockingStatus();
 
         /**
          * @brief Sets the default Linux specific line discipline modes.
          */
-        void SetDefaultLinuxSpecificModes() const;
+        void SetDefaultLinuxSpecificModes();
 
         /**
          * @brief Sets the default serial port input modes.
          */
-        void SetDefaultInputModes() const;
+        void SetDefaultInputModes();
 
         /**
          * @brief Sets the default serial port output modes.
          */
-        void SetDefaultOutputModes() const;
+        void SetDefaultOutputModes();
 
         /**
          * @brief Sets the default serial port control modes.
          */
-        void SetDefaultControlModes() const;
+        void SetDefaultControlModes();
 
         /**
          * @brief Sets the default serial port local modes.
          */
-        void SetDefaultLocalModes() const;
+        void SetDefaultLocalModes();
 
 
         /**
@@ -449,182 +449,182 @@ namespace LibSerial
     }
 
     void
-    SerialStreamBuf::FlushInputBuffer() const
+    SerialStreamBuf::FlushInputBuffer()
     {
         mImpl->FlushInputBuffer();
         return;
     }
 
     void
-    SerialStreamBuf::FlushOutputBuffer() const
+    SerialStreamBuf::FlushOutputBuffer()
     {
         mImpl->FlushOutputBuffer();
         return;
     }
 
     void
-    SerialStreamBuf::FlushIOBuffers() const
+    SerialStreamBuf::FlushIOBuffers()
     {
         mImpl->FlushIOBuffers();
         return;
     }
 
     bool
-    SerialStreamBuf::IsDataAvailable() const
+    SerialStreamBuf::IsDataAvailable()
     {
         return mImpl->IsDataAvailable();
     }
 
     bool
-    SerialStreamBuf::IsOpen() const
+    SerialStreamBuf::IsOpen()
     {
         return mImpl->IsOpen();
     }
 
     void
-    SerialStreamBuf::SetDefaultSerialPortParameters() const
+    SerialStreamBuf::SetDefaultSerialPortParameters()
     {
         mImpl->SetDefaultSerialPortParameters();
         return;
     }
 
     void
-    SerialStreamBuf::SetBaudRate(const BaudRate& baudRate) const
+    SerialStreamBuf::SetBaudRate(const BaudRate& baudRate)
     {
         mImpl->SetBaudRate(baudRate);
         return;
     }
 
     BaudRate
-    SerialStreamBuf::GetBaudRate() const
+    SerialStreamBuf::GetBaudRate()
     {
         return mImpl->GetBaudRate();
     }
 
     void
-    SerialStreamBuf::SetCharacterSize(const CharacterSize& characterSize) const
+    SerialStreamBuf::SetCharacterSize(const CharacterSize& characterSize)
     {
         mImpl->SetCharacterSize(characterSize);
         return;
     }
 
     CharacterSize
-    SerialStreamBuf::GetCharacterSize() const
+    SerialStreamBuf::GetCharacterSize()
     {
         return mImpl->GetCharacterSize();
     }
 
     void
-    SerialStreamBuf::SetFlowControl(const FlowControl& flowControlType) const
+    SerialStreamBuf::SetFlowControl(const FlowControl& flowControlType)
     {
         mImpl->SetFlowControl(flowControlType);
         return;
     }
 
     FlowControl
-    SerialStreamBuf::GetFlowControl() const
+    SerialStreamBuf::GetFlowControl()
     {
         return mImpl->GetFlowControl();
     }
 
     void
-    SerialStreamBuf::SetParity(const Parity& parityType) const
+    SerialStreamBuf::SetParity(const Parity& parityType)
     {
         mImpl->SetParity(parityType);
         return;
     }
 
     Parity
-    SerialStreamBuf::GetParity() const
+    SerialStreamBuf::GetParity()
     {
         return mImpl->GetParity();
     }
 
     void
-    SerialStreamBuf::SetStopBits(const StopBits& stopBits) const
+    SerialStreamBuf::SetStopBits(const StopBits& stopBits)
     {
         mImpl->SetStopBits(stopBits);
         return;
     }
 
     StopBits
-    SerialStreamBuf::GetStopBits() const
+    SerialStreamBuf::GetStopBits()
     {
         return mImpl->GetStopBits();
     }
 
     void
-    SerialStreamBuf::SetVMin(const short vmin) const
+    SerialStreamBuf::SetVMin(const short vmin)
     {
         mImpl->SetVMin(vmin);
         return;
     }
 
     short
-    SerialStreamBuf::GetVMin() const
+    SerialStreamBuf::GetVMin()
     {
         return mImpl->GetVMin();
     }
 
     void
-    SerialStreamBuf::SetVTime(const short vtime) const
+    SerialStreamBuf::SetVTime(const short vtime)
     {
         mImpl->SetVTime(vtime);
         return;
     }
 
     short
-    SerialStreamBuf::GetVTime() const
+    SerialStreamBuf::GetVTime()
     {
         return mImpl->GetVTime();
     }
 
     void
-    SerialStreamBuf::SetDTR(const bool dtrState) const
+    SerialStreamBuf::SetDTR(const bool dtrState)
     {
         mImpl->SetDTR(dtrState);
         return;
     }
 
     bool
-    SerialStreamBuf::GetDTR() const
+    SerialStreamBuf::GetDTR()
     {
         return mImpl->GetDTR();
     }
 
     void
-    SerialStreamBuf::SetRTS(const bool rtsState) const
+    SerialStreamBuf::SetRTS(const bool rtsState)
     {
         mImpl->SetRTS(rtsState);
         return;
     }
 
     bool
-    SerialStreamBuf::GetRTS() const
+    SerialStreamBuf::GetRTS()
     {
         return mImpl->GetRTS();
     }
 
     bool
-    SerialStreamBuf::GetCTS() const
+    SerialStreamBuf::GetCTS()
     {
         return mImpl->GetCTS();
     }
 
     bool
-    SerialStreamBuf::GetDSR()  const
+    SerialStreamBuf::GetDSR()
     {
         return mImpl->GetDSR();
     }
 
     int
-    SerialStreamBuf::GetFileDescriptor() const
+    SerialStreamBuf::GetFileDescriptor()
     {
         return mImpl->GetFileDescriptor();
     }
 
     std::vector<std::string>
-    SerialStreamBuf::GetAvailableSerialPorts() const
+    SerialStreamBuf::GetAvailableSerialPorts()
     {
         return mImpl->GetAvailableSerialPorts();
     }
@@ -822,7 +822,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::FlushInputBuffer() const
+    SerialStreamBuf::Implementation::FlushInputBuffer()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -840,7 +840,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::FlushOutputBuffer() const
+    SerialStreamBuf::Implementation::FlushOutputBuffer()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -858,7 +858,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::FlushIOBuffers() const
+    SerialStreamBuf::Implementation::FlushIOBuffers()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -876,14 +876,14 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::IsOpen() const
+    SerialStreamBuf::Implementation::IsOpen()
     {
         return (this->mFileDescriptor != -1);
     }
 
     inline
     bool
-    SerialStreamBuf::Implementation::IsDataAvailable() const
+    SerialStreamBuf::Implementation::IsDataAvailable()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -909,7 +909,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialStreamBuf::Implementation::SetDefaultSerialPortParameters() const
+    SerialStreamBuf::Implementation::SetDefaultSerialPortParameters()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -939,7 +939,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetBaudRate(const BaudRate& baudRate) const
+    SerialStreamBuf::Implementation::SetBaudRate(const BaudRate& baudRate)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -978,7 +978,7 @@ namespace LibSerial
 
     inline
     BaudRate
-    SerialStreamBuf::Implementation::GetBaudRate() const
+    SerialStreamBuf::Implementation::GetBaudRate()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1014,7 +1014,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetCharacterSize(const CharacterSize& characterSize) const
+    SerialStreamBuf::Implementation::SetCharacterSize(const CharacterSize& characterSize)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1066,7 +1066,7 @@ namespace LibSerial
 
     inline
     CharacterSize
-    SerialStreamBuf::Implementation::GetCharacterSize() const
+    SerialStreamBuf::Implementation::GetCharacterSize()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1090,7 +1090,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetFlowControl(const FlowControl& flowControlType) const
+    SerialStreamBuf::Implementation::SetFlowControl(const FlowControl& flowControlType)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1154,7 +1154,7 @@ namespace LibSerial
 
     inline
     FlowControl
-    SerialStreamBuf::Implementation::GetFlowControl() const
+    SerialStreamBuf::Implementation::GetFlowControl()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1204,7 +1204,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetParity(const Parity& parityType) const
+    SerialStreamBuf::Implementation::SetParity(const Parity& parityType)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1257,7 +1257,7 @@ namespace LibSerial
 
     inline
     Parity
-    SerialStreamBuf::Implementation::GetParity() const
+    SerialStreamBuf::Implementation::GetParity()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1298,7 +1298,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetStopBits(const StopBits& stopBits) const
+    SerialStreamBuf::Implementation::SetStopBits(const StopBits& stopBits)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1343,7 +1343,7 @@ namespace LibSerial
 
     inline
     StopBits
-    SerialStreamBuf::Implementation::GetStopBits() const
+    SerialStreamBuf::Implementation::GetStopBits()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1375,7 +1375,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialStreamBuf::Implementation::SetVMin(const short vmin) const
+    SerialStreamBuf::Implementation::SetVMin(const short vmin)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1413,7 +1413,7 @@ namespace LibSerial
 
     inline
     short 
-    SerialStreamBuf::Implementation::GetVMin() const
+    SerialStreamBuf::Implementation::GetVMin()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1436,7 +1436,7 @@ namespace LibSerial
 
     inline
     void 
-    SerialStreamBuf::Implementation::SetVTime(const short vtime) const
+    SerialStreamBuf::Implementation::SetVTime(const short vtime)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1474,7 +1474,7 @@ namespace LibSerial
 
     inline
     short 
-    SerialStreamBuf::Implementation::GetVTime() const
+    SerialStreamBuf::Implementation::GetVTime()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1497,7 +1497,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDTR(const bool dtrState) const
+    SerialStreamBuf::Implementation::SetDTR(const bool dtrState)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1512,7 +1512,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetDTR() const
+    SerialStreamBuf::Implementation::GetDTR()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1525,7 +1525,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetRTS(const bool rtsState) const
+    SerialStreamBuf::Implementation::SetRTS(const bool rtsState)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1540,7 +1540,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetRTS() const
+    SerialStreamBuf::Implementation::GetRTS()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1553,7 +1553,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetCTS() const
+    SerialStreamBuf::Implementation::GetCTS()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1566,7 +1566,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetDSR() const
+    SerialStreamBuf::Implementation::GetDSR()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1579,7 +1579,7 @@ namespace LibSerial
 
     inline
     int
-    SerialStreamBuf::Implementation::GetFileDescriptor() const
+    SerialStreamBuf::Implementation::GetFileDescriptor()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1592,7 +1592,7 @@ namespace LibSerial
 
     inline
     std::vector<std::string>
-    SerialStreamBuf::Implementation::GetAvailableSerialPorts() const
+    SerialStreamBuf::Implementation::GetAvailableSerialPorts()
     {
         const int array_size = 3;
         int file_descriptor = -1;
@@ -1641,7 +1641,7 @@ namespace LibSerial
     inline
     void
     SerialStreamBuf::Implementation::SetModemControlLine(const int  modemLine,
-                                                         const bool lineState) const
+                                                         const bool lineState)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1693,7 +1693,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetModemControlLine(const int modemLine) const
+    SerialStreamBuf::Implementation::GetModemControlLine(const int modemLine)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1731,7 +1731,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetSerialPortBlockingStatus(const bool blockingStatus) const
+    SerialStreamBuf::Implementation::SetSerialPortBlockingStatus(const bool blockingStatus)
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1763,7 +1763,7 @@ namespace LibSerial
 
     inline
     bool
-    SerialStreamBuf::Implementation::GetSerialPortBlockingStatus() const
+    SerialStreamBuf::Implementation::GetSerialPortBlockingStatus()
     {
         // Throw an exception if the serial port is not open.
         if (!this->IsOpen())
@@ -1789,7 +1789,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultLinuxSpecificModes() const
+    SerialStreamBuf::Implementation::SetDefaultLinuxSpecificModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1824,7 +1824,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultInputModes() const
+    SerialStreamBuf::Implementation::SetDefaultInputModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1858,7 +1858,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultOutputModes() const
+    SerialStreamBuf::Implementation::SetDefaultOutputModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1891,7 +1891,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultControlModes() const
+    SerialStreamBuf::Implementation::SetDefaultControlModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())
@@ -1925,7 +1925,7 @@ namespace LibSerial
 
     inline
     void
-    SerialStreamBuf::Implementation::SetDefaultLocalModes() const
+    SerialStreamBuf::Implementation::SetDefaultLocalModes()
     {
         // Make sure that the serial port is open.
         if (!this->IsOpen())

--- a/src/SerialStreamBuf.h
+++ b/src/SerialStreamBuf.h
@@ -263,6 +263,12 @@ namespace LibSerial
         int GetFileDescriptor();
 
         /**
+         * @brief Gets the number of bytes available in the read buffer.
+         * @return Returns the number of bytes avilable in the read buffer.
+         */
+        int GetNumberOfBytesAvailable();
+
+        /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 

--- a/src/SerialStreamBuf.h
+++ b/src/SerialStreamBuf.h
@@ -94,6 +94,11 @@ namespace LibSerial
         void Close();
 
         /**
+         * @brief Waits until the write buffer is drained and then returns.
+         */
+        void DrainWriteBuffer();
+
+        /**
          * @brief Flushes the serial port input buffer.
          */
         void FlushInputBuffer();

--- a/src/SerialStreamBuf.h
+++ b/src/SerialStreamBuf.h
@@ -80,7 +80,7 @@ namespace LibSerial
         /**
          * @brief Opens the serial port associated with the specified
          *        file name and the specified mode.
-         * @param fileName The file name of the serial port object.
+         * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
          */

--- a/src/SerialStreamBuf.h
+++ b/src/SerialStreamBuf.h
@@ -96,101 +96,101 @@ namespace LibSerial
         /**
          * @brief Flushes the serial port input buffer.
          */
-        void FlushInputBuffer() const;
+        void FlushInputBuffer();
 
         /**
          * @brief Flushes the serial port output buffer.
          */
-        void FlushOutputBuffer() const;
+        void FlushOutputBuffer();
 
         /**
          * @brief Flushes the serial port input and output buffers.
          */
-        void FlushIOBuffers() const;
+        void FlushIOBuffers();
 
         /**
          * @brief Checks if data is available at the input of the serial port.
          * @return Returns true iff data is available to read.
          */
-        bool IsDataAvailable() const;
+        bool IsDataAvailable();
 
         /**
          * @brief Determines if the serial port is open for I/O.
          * @return Returns true iff the serial port is open.
          */
-        bool IsOpen() const;
+        bool IsOpen();
 
         /**
          * @brief Sets all serial port paramters to their default values.
          */
-        void SetDefaultSerialPortParameters() const;
+        void SetDefaultSerialPortParameters();
 
         /**
          * @brief Sets the baud rate for the serial port to the specified value
          * @param baudRate The baud rate to be set for the serial port.
          */
-        void SetBaudRate(const BaudRate& baudRate) const;
+        void SetBaudRate(const BaudRate& baudRate);
 
         /**
          * @brief Gets the current baud rate for the serial port.
          * @return Returns the baud rate.
          */
-        BaudRate GetBaudRate() const;
+        BaudRate GetBaudRate();
 
         /**
          * @brief Sets the character size for the serial port.
          * @param characterSize The character size to be set.
          */
-        void SetCharacterSize(const CharacterSize& characterSize) const;
+        void SetCharacterSize(const CharacterSize& characterSize);
 
         /**
          * @brief Gets the character size being used for serial communication.
          * @return Returns the current character size. 
          */
-        CharacterSize GetCharacterSize() const;
+        CharacterSize GetCharacterSize();
 
         /**
          * @brief Sets flow control for the serial port.
          * @param flowControlType The flow control type to be set.
          */
-        void SetFlowControl(const FlowControl& flowControlType) const;
+        void SetFlowControl(const FlowControl& flowControlType);
 
         /**
          * @brief Gets the current flow control setting.
          * @return Returns the flow control type of the serial port.
          */
-        FlowControl GetFlowControl() const;
+        FlowControl GetFlowControl();
 
         /**
          * @brief Sets the parity type for the serial port.
          * @param parityType The parity type to be set.
          */
-        void SetParity(const Parity& parityType) const;
+        void SetParity(const Parity& parityType);
 
         /**
          * @brief Gets the parity type for the serial port.
          * @return Returns the parity type.
          */
-        Parity GetParity() const;
+        Parity GetParity();
 
         /**
          * @brief Sets the number of stop bits to be used with the serial port.
          * @param stopBits The number of stop bits to set.
          */
-        void SetStopBits(const StopBits& stopBits) const;
+        void SetStopBits(const StopBits& stopBits);
 
         /**
          * @brief Gets the number of stop bits currently being used by the serial
          * @return Returns the number of stop bits.
          */
-        StopBits GetStopBits() const;
+        StopBits GetStopBits();
 
         /**
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @note See VMIN in man termios(3).
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(const short vmin) const;
+        void SetVMin(const short vmin);
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -198,71 +198,71 @@ namespace LibSerial
          * @return Returns the minimum number of characters for
          *         non-canonical reads.
          */
-        short GetVMin() const;
+        short GetVMin();
 
         /** 
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds.
          */
-        void SetVTime(const short vtime) const;
+        void SetVTime(const short vtime);
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds. 
          */
-        short GetVTime() const;
+        short GetVTime();
 
         /**
          * @brief Sets the DTR line to the specified value.
          * @param dtrState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetDTR(const bool dtrState = true) const;
+        void SetDTR(const bool dtrState = true);
 
         /**
          * @brief Gets the status of the DTR line.
          * @return Returns true iff the status of the DTR line is high.
          */
-        bool GetDTR() const;
+        bool GetDTR();
 
         /**
          * @brief Set the RTS line to the specified value.
          * @param rtsState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetRTS(const bool rtsState = true) const;
+        void SetRTS(const bool rtsState = true);
 
         /**
          * @brief Get the status of the RTS line.
          * @return Returns true iff the status of the RTS line is high.
          */
-        bool GetRTS() const;
+        bool GetRTS();
 
         /**
          * @brief Get the status of the CTS line.
          * @return Returns true iff the status of the CTS line is high.
          */
-        bool GetCTS() const;
+        bool GetCTS();
 
         /**
          * @brief Get the status of the DSR line.
          * @return Returns true iff the status of the DSR line is high.
          */
-        bool GetDSR() const;
+        bool GetDSR();
 
         /**
          * @brief Gets the serial port file descriptor.
          * @return Returns the serial port file descriptor.
          */
-        int GetFileDescriptor() const;
+        int GetFileDescriptor();
 
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
-        std::vector<std::string> GetAvailableSerialPorts() const;
+        std::vector<std::string> GetAvailableSerialPorts();
 
 
     protected:

--- a/src/SerialStreamBuf.h
+++ b/src/SerialStreamBuf.h
@@ -72,7 +72,8 @@ namespace LibSerial
                                  const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT);
 
         /**
-         *  @brief Default Destructor.
+         * @brief Default Destructor for a SerialStreamBuf object. Closes the
+         *        serial port associated with mFileDescriptor if open.
          */
         virtual ~SerialStreamBuf();
 
@@ -95,101 +96,101 @@ namespace LibSerial
         /**
          * @brief Flushes the serial port input buffer.
          */
-        void FlushInputBuffer();
+        void FlushInputBuffer() const;
 
         /**
          * @brief Flushes the serial port output buffer.
          */
-        void FlushOutputBuffer();
+        void FlushOutputBuffer() const;
 
         /**
          * @brief Flushes the serial port input and output buffers.
          */
-        void FlushIOBuffers();
+        void FlushIOBuffers() const;
 
         /**
          * @brief Checks if data is available at the input of the serial port.
          * @return Returns true iff data is available to read.
          */
-        bool IsDataAvailable();
+        bool IsDataAvailable() const;
 
         /**
          * @brief Determines if the serial port is open for I/O.
          * @return Returns true iff the serial port is open.
          */
-        bool IsOpen();
+        bool IsOpen() const;
 
         /**
          * @brief Sets all serial port paramters to their default values.
          */
-        void SetDefaultSerialPortParameters();
+        void SetDefaultSerialPortParameters() const;
 
         /**
          * @brief Sets the baud rate for the serial port to the specified value
          * @param baudRate The baud rate to be set for the serial port.
          */
-        void SetBaudRate(const BaudRate& baudRate);
+        void SetBaudRate(const BaudRate& baudRate) const;
 
         /**
          * @brief Gets the current baud rate for the serial port.
          * @return Returns the baud rate.
          */
-        BaudRate GetBaudRate();
+        BaudRate GetBaudRate() const;
 
         /**
          * @brief Sets the character size for the serial port.
          * @param characterSize The character size to be set.
          */
-        void SetCharacterSize(const CharacterSize& characterSize);
+        void SetCharacterSize(const CharacterSize& characterSize) const;
 
         /**
          * @brief Gets the character size being used for serial communication.
          * @return Returns the current character size. 
          */
-        CharacterSize GetCharacterSize();
+        CharacterSize GetCharacterSize() const;
 
         /**
          * @brief Sets flow control for the serial port.
          * @param flowControlType The flow control type to be set.
          */
-        void SetFlowControl(const FlowControl& flowControlType);
+        void SetFlowControl(const FlowControl& flowControlType) const;
 
         /**
          * @brief Gets the current flow control setting.
          * @return Returns the flow control type of the serial port.
          */
-        FlowControl GetFlowControl();
+        FlowControl GetFlowControl() const;
 
         /**
          * @brief Sets the parity type for the serial port.
          * @param parityType The parity type to be set.
          */
-        void SetParity(const Parity& parityType);
+        void SetParity(const Parity& parityType) const;
 
         /**
          * @brief Gets the parity type for the serial port.
          * @return Returns the parity type.
          */
-        Parity GetParity();
+        Parity GetParity() const;
 
         /**
          * @brief Sets the number of stop bits to be used with the serial port.
          * @param stopBits The number of stop bits to set.
          */
-        void SetStopBits(const StopBits& stopBits);
+        void SetStopBits(const StopBits& stopBits) const;
 
         /**
          * @brief Gets the number of stop bits currently being used by the serial
          * @return Returns the number of stop bits.
          */
-        StopBits GetStopBits();
+        StopBits GetStopBits() const;
 
         /**
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @note See VMIN in man termios(3).
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(const short vmin);
+        void SetVMin(const short vmin) const;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -197,71 +198,71 @@ namespace LibSerial
          * @return Returns the minimum number of characters for
          *         non-canonical reads.
          */
-        short GetVMin();
+        short GetVMin() const;
 
         /** 
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds.
          */
-        void SetVTime(const short vtime);
+        void SetVTime(const short vtime) const;
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds. 
          */
-        short GetVTime();
+        short GetVTime() const;
 
         /**
          * @brief Sets the DTR line to the specified value.
          * @param dtrState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetDTR(const bool dtrState = true);
+        void SetDTR(const bool dtrState = true) const;
 
         /**
          * @brief Gets the status of the DTR line.
          * @return Returns true iff the status of the DTR line is high.
          */
-        bool GetDTR();
+        bool GetDTR() const;
 
         /**
          * @brief Set the RTS line to the specified value.
          * @param rtsState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetRTS(const bool rtsState = true);
+        void SetRTS(const bool rtsState = true) const;
 
         /**
          * @brief Get the status of the RTS line.
          * @return Returns true iff the status of the RTS line is high.
          */
-        bool GetRTS();
+        bool GetRTS() const;
 
         /**
          * @brief Get the status of the CTS line.
          * @return Returns true iff the status of the CTS line is high.
          */
-        bool GetCTS();
+        bool GetCTS() const;
 
         /**
          * @brief Get the status of the DSR line.
          * @return Returns true iff the status of the DSR line is high.
          */
-        bool GetDSR();
+        bool GetDSR() const;
 
         /**
          * @brief Gets the serial port file descriptor.
          * @return Returns the serial port file descriptor.
          */
-        int GetFileDescriptor();
+        int GetFileDescriptor() const;
 
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
-        std::vector<std::string> GetAvailableSerialPorts();
+        std::vector<std::string> GetAvailableSerialPorts() const;
 
 
     protected:

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -384,8 +384,8 @@ protected:
             serialStream1.SetBaudRate(baud_rate);
             serialStream2.SetBaudRate(baud_rate);
 
-            BaudRate baudRate1 = serialStream1.GetBaudRate();
-            BaudRate baudRate2 = serialStream2.GetBaudRate();
+            const auto baudRate1 = serialStream1.GetBaudRate();
+            const auto baudRate2 = serialStream2.GetBaudRate();
 
             ASSERT_EQ(baudRate1, baud_rate);
             ASSERT_EQ(baudRate2, baud_rate);
@@ -417,8 +417,8 @@ protected:
             serialStream1.SetCharacterSize(char_size);
             serialStream2.SetCharacterSize(char_size);
 
-            CharacterSize characterSize1 = serialStream1.GetCharacterSize();
-            CharacterSize characterSize2 = serialStream2.GetCharacterSize();
+            const auto characterSize1 = serialStream1.GetCharacterSize();
+            const auto characterSize2 = serialStream2.GetCharacterSize();
 
             ASSERT_EQ(characterSize1, char_size);
             ASSERT_EQ(characterSize2, char_size);
@@ -441,16 +441,13 @@ protected:
         ASSERT_TRUE(serialStream1.IsOpen());
         ASSERT_TRUE(serialStream2.IsOpen());
 
-        FlowControl flowControl1 = FlowControl::FLOW_CONTROL_DEFAULT;
-        FlowControl flowControl2 = FlowControl::FLOW_CONTROL_DEFAULT;
-
         for (const auto flow_control: flowControlTypes)
         {
             serialStream1.SetFlowControl(flow_control);
             serialStream1.SetFlowControl(flow_control);
 
-            flowControl1 = serialStream1.GetFlowControl();
-            flowControl2 = serialStream1.GetFlowControl();
+            const auto flowControl1 = serialStream1.GetFlowControl();
+            const auto flowControl2 = serialStream1.GetFlowControl();
 
             ASSERT_EQ(flowControl1, flow_control);
             ASSERT_EQ(flowControl2, flow_control);
@@ -471,16 +468,13 @@ protected:
         ASSERT_TRUE(serialStream1.IsOpen());
         ASSERT_TRUE(serialStream2.IsOpen());
 
-        Parity parity1 = Parity::PARITY_DEFAULT;
-        Parity parity2 = Parity::PARITY_DEFAULT;
-
         for (const auto parity: parityTypes)
         {
             serialStream1.SetParity(parity);
             serialStream2.SetParity(parity);
 
-            parity1 = serialStream1.GetParity();
-            parity2 = serialStream2.GetParity();
+            const auto parity1 = serialStream1.GetParity();
+            const auto parity2 = serialStream2.GetParity();
 
             ASSERT_EQ(parity1, parity);
             ASSERT_EQ(parity2, parity);
@@ -501,16 +495,13 @@ protected:
         ASSERT_TRUE(serialStream1.IsOpen());
         ASSERT_TRUE(serialStream2.IsOpen());
 
-        StopBits numberOfStopBits1 = StopBits::STOP_BITS_DEFAULT;
-        StopBits numberOfStopBits2 = StopBits::STOP_BITS_DEFAULT;
-
         for (const auto stop_bits: stopBits)
         {
             serialStream1.SetStopBits(stop_bits);
             serialStream2.SetStopBits(stop_bits);
 
-            numberOfStopBits1 = serialStream1.GetStopBits();
-            numberOfStopBits2 = serialStream2.GetStopBits();
+            const auto numberOfStopBits1 = serialStream1.GetStopBits();
+            const auto numberOfStopBits2 = serialStream2.GetStopBits();
 
             ASSERT_EQ(numberOfStopBits1, stop_bits);
             ASSERT_EQ(numberOfStopBits2, stop_bits);
@@ -1508,8 +1499,8 @@ protected:
         char writeBuffer1[] = "abc";
         unsigned char writeBuffer2[] = "ABC";
 
-        char readBuffer1[3] = {};
-        unsigned char readBuffer2[3] = {};
+        char* readBuffer1 = new char[3];
+        unsigned char* readBuffer2 = new unsigned char[3];
 
         serialPort1.Write(writeBuffer1, 3);
         serialPort2.Write(writeBuffer2, 3);
@@ -1517,8 +1508,8 @@ protected:
         tcdrain(serialPort1.GetFileDescriptor());
         tcdrain(serialPort2.GetFileDescriptor());
 
-        serialPort1.Read(*readBuffer1, 3, timeOutMilliseconds);
-        serialPort2.Read(*readBuffer2, 3, timeOutMilliseconds);
+        serialPort1.Read(readBuffer1, 3, timeOutMilliseconds);
+        serialPort2.Read(readBuffer2, 3, timeOutMilliseconds);
 
         for (size_t i = 0; i < 3; i++)
         {
@@ -1528,8 +1519,8 @@ protected:
 
         try
         {
-            serialPort1.Read(*readBuffer1, 3, 1);
-            serialPort2.Read(*readBuffer2, 3, 1);
+            serialPort1.Read(readBuffer1, 3, 1);
+            serialPort2.Read(readBuffer2, 3, 1);
         }
         catch(...)
         {
@@ -1542,8 +1533,8 @@ protected:
 
         try
         {
-            serialPort1.Read(*readBuffer1, 0, 5);
-            serialPort2.Read(*readBuffer2, 0, 5);
+            serialPort1.Read(readBuffer1, 0, 5);
+            serialPort2.Read(readBuffer2, 0, 5);
         }
         catch(...)
         {

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -1494,7 +1494,7 @@ protected:
         ASSERT_TRUE(serialPort1.IsOpen());
         ASSERT_TRUE(serialPort2.IsOpen());
 
-        const size_t array_size = 75;
+        const size_t data_count = 75;
 
         bool timeOutTestPass = false;
 
@@ -1505,7 +1505,7 @@ protected:
         DataBuffer readVector2;
 
         // Test using ASCII characters.
-        for (unsigned char i = 0; i < array_size; i++)
+        for (unsigned char i = 0; i < data_count; i++)
         {
             writeVector1.push_back((char)(48 + i));
             writeVector2.push_back((char)(122 - i));
@@ -1517,11 +1517,34 @@ protected:
         tcdrain(serialPort1.GetFileDescriptor());
         tcdrain(serialPort2.GetFileDescriptor());
 
-        serialPort1.Read(readVector2, array_size, timeOutMilliseconds);
-        serialPort2.Read(readVector1, array_size, timeOutMilliseconds);
+        serialPort1.Read(readVector2, data_count, timeOutMilliseconds);
+        serialPort2.Read(readVector1, data_count, timeOutMilliseconds);
 
         ASSERT_EQ(readVector1, writeVector1);
         ASSERT_EQ(readVector2, writeVector2);
+
+        readVector1.clear();
+        readVector2.clear();
+
+        try
+        {
+            serialPort1.Write(writeVector1);
+            serialPort2.Write(writeVector2);
+
+            tcdrain(serialPort1.GetFileDescriptor());
+            tcdrain(serialPort2.GetFileDescriptor());
+
+            serialPort1.Read(readVector2, 0, 75);
+            serialPort2.Read(readVector1, 0, 75);
+        }
+        catch(...)
+        {
+            timeOutTestPass = true;
+        }
+
+        ASSERT_TRUE(timeOutTestPass);
+
+        timeOutTestPass = false;
 
         try
         {
@@ -1533,20 +1556,6 @@ protected:
             timeOutTestPass = true;
         }
         
-        ASSERT_TRUE(timeOutTestPass);
-        
-        timeOutTestPass = false;
-
-        try
-        {
-            serialPort1.Read(readVector1, 0, 5);
-            serialPort2.Read(readVector2, 0, 5);
-        }
-        catch(...)
-        {
-            timeOutTestPass = true;
-        }
-
         ASSERT_TRUE(timeOutTestPass);
 
         serialPort1.Close();
@@ -1592,10 +1601,19 @@ protected:
         
         timeOutTestPass = false;
 
+        readString1.clear();
+        readString2.clear();
+
         try
         {
-            serialPort1.Read(readString1, 0, 5);
-            serialPort2.Read(readString2, 0, 5);
+            serialPort1.Write(writeString1);
+            serialPort2.Write(writeString2);
+
+            tcdrain(serialPort1.GetFileDescriptor());
+            tcdrain(serialPort2.GetFileDescriptor());
+
+            serialPort2.Read(readString1, 0, 75);
+            serialPort1.Read(readString2, 0, 75);
         }
         catch(...)
         {

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -20,6 +20,7 @@
 
 
 #include <chrono>
+#include <iostream>
 #include <gtest/gtest.h>
 #include <mutex>
 #include <thread>
@@ -734,6 +735,53 @@ protected:
 
         ASSERT_GT(fileDescriptor1, 0);
         ASSERT_GT(fileDescriptor2, 0);
+
+        serialStream1.Close();
+        serialStream2.Close();
+
+        ASSERT_FALSE(serialStream1.IsOpen());
+        ASSERT_FALSE(serialStream2.IsOpen());
+    }
+
+    void testSerialStreamGetNumberOfBytesAvailable()
+    {
+        serialStream1.Open(TEST_SERIAL_PORT_1);
+        serialStream2.Open(TEST_SERIAL_PORT_2);
+
+        ASSERT_TRUE(serialStream1.IsOpen());
+        ASSERT_TRUE(serialStream2.IsOpen());
+
+        char writeByte1 = 'a';
+        char writeByte2 = 'A';
+
+        char readByte1  = 'b';
+        char readByte2  = 'B';
+
+        int bytesAvailable1 = 0;
+        int bytesAvailable2 = 0;
+
+        serialStream1.write(&writeByte1, 1);
+        serialStream2.write(&writeByte2, 1);
+
+        serialStream1.DrainWriteBuffer();
+        serialStream2.DrainWriteBuffer();
+
+        usleep(readBufferDelay);
+
+        bytesAvailable1 = serialStream1.GetNumberOfBytesAvailable();
+        bytesAvailable2 = serialStream2.GetNumberOfBytesAvailable();
+
+        ASSERT_EQ(bytesAvailable1, 1);
+        ASSERT_EQ(bytesAvailable2, 1);
+
+        serialStream1.read(&readByte2, 1);
+        serialStream2.read(&readByte1, 1);
+
+        bytesAvailable1 = serialStream1.GetNumberOfBytesAvailable();
+        bytesAvailable2 = serialStream2.GetNumberOfBytesAvailable();
+
+        ASSERT_EQ(bytesAvailable1, 0);
+        ASSERT_EQ(bytesAvailable2, 0);
 
         serialStream1.Close();
         serialStream2.Close();
@@ -1501,6 +1549,56 @@ protected:
         ASSERT_FALSE(serialPort2.IsOpen());
     }
 
+    void testSerialPortGetNumberOfBytesAvailable()
+    {
+        serialPort1.Open(TEST_SERIAL_PORT_1);
+        serialPort2.Open(TEST_SERIAL_PORT_2);
+
+        ASSERT_TRUE(serialPort1.IsOpen());
+        ASSERT_TRUE(serialPort2.IsOpen());
+
+        char writeByte1 = 'a';
+        char writeByte2 = 'A';
+
+        char readByte1  = 'b';
+        char readByte2  = 'B';
+
+        int bytesAvailable1 = 0;
+        int bytesAvailable2 = 0;
+
+        bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
+        bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
+
+        serialPort1.WriteByte(writeByte1);
+        serialPort2.WriteByte(writeByte2);
+
+        serialPort1.DrainWriteBuffer();
+        serialPort2.DrainWriteBuffer();
+
+        usleep(readBufferDelay);
+
+        bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
+        bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
+
+        ASSERT_EQ(bytesAvailable1, 1);
+        ASSERT_EQ(bytesAvailable2, 1);
+
+        serialPort1.ReadByte(readByte2, 1);
+        serialPort2.ReadByte(readByte1, 1);
+
+        bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
+        bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
+
+        ASSERT_EQ(bytesAvailable1, 0);
+        ASSERT_EQ(bytesAvailable2, 0);
+
+        serialPort1.Close();
+        serialPort2.Close();
+
+        ASSERT_FALSE(serialPort1.IsOpen());
+        ASSERT_FALSE(serialPort2.IsOpen());
+    }
+
     void testSerialPortGetAvailableSerialPorts()
     {
         serialPort1.Open(TEST_SERIAL_PORT_1);
@@ -1783,11 +1881,12 @@ protected:
             serialStream1 << writeString1 << std::endl;
             serialStream1.DrainWriteBuffer();
 
-            entryTime = getTimeInMicroSeconds();
-            usleep(500);
-            currentTime = getTimeInMicroSeconds();
-            elapsedTime = currentTime - entryTime;
-            ASSERT_GT(elapsedTime, (size_t)0);
+            // entryTime = getTimeInMicroSeconds();
+            // std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            // // usleep(500);
+            // currentTime = getTimeInMicroSeconds();
+            // elapsedTime = currentTime - entryTime;
+            // ASSERT_GT(elapsedTime, (size_t)0);
 
             if (serialStream1.IsDataAvailable())
             {
@@ -1827,11 +1926,12 @@ protected:
             serialStream2 << writeString2 << std::endl;
             serialStream2.DrainWriteBuffer();
 
-            entryTime = getTimeInMicroSeconds();
-            usleep(500);
-            currentTime = getTimeInMicroSeconds();
-            elapsedTime = currentTime - entryTime;
-            ASSERT_GT(elapsedTime, (size_t)0);
+            // entryTime = getTimeInMicroSeconds();
+            // std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            // // usleep(500);
+            // currentTime = getTimeInMicroSeconds();
+            // elapsedTime = currentTime - entryTime;
+            // ASSERT_GT(elapsedTime, (size_t)0);
 
             if (serialStream2.IsDataAvailable())
             {
@@ -1873,11 +1973,12 @@ protected:
             serialPort1.Write(writeString1 + '\n');
             serialPort1.DrainWriteBuffer();
 
-            entryTime = getTimeInMicroSeconds();
-            usleep(500);
-            currentTime = getTimeInMicroSeconds();
-            elapsedTime = currentTime - entryTime;
-            ASSERT_GT(elapsedTime, (size_t)0);
+            // entryTime = getTimeInMicroSeconds();
+            // std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            // // usleep(500);
+            // currentTime = getTimeInMicroSeconds();
+            // elapsedTime = currentTime - entryTime;
+            // ASSERT_GT(elapsedTime, (size_t)0);
 
             if (serialPort1.IsDataAvailable())
             {
@@ -1922,11 +2023,12 @@ protected:
             serialPort2.Write(writeString2 + '\n');
             serialPort2.DrainWriteBuffer();
 
-            entryTime = getTimeInMicroSeconds();
-            usleep(500);
-            currentTime = getTimeInMicroSeconds();
-            elapsedTime = currentTime - entryTime;
-            ASSERT_GT(elapsedTime, (size_t)0);
+            // entryTime = getTimeInMicroSeconds();
+            // std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            // // usleep(500);
+            // currentTime = getTimeInMicroSeconds();
+            // elapsedTime = currentTime - entryTime;
+            // ASSERT_GT(elapsedTime, (size_t)0);
 
             if (serialPort2.IsDataAvailable())
             {
@@ -2185,6 +2287,16 @@ TEST_F(LibSerialTest, testSerialStreamGetFileDescriptor)
     }
 }
 
+TEST_F(LibSerialTest, testSerialStreamGetNumberOfBytesAvailable)
+{
+    SCOPED_TRACE("Serial Stream GetNumberOfBytesAvailable() Test");
+    
+    for (size_t i = 0; i < numberOfTestIterations; i++)
+    {
+        testSerialStreamGetNumberOfBytesAvailable();
+    }
+}
+
 TEST_F(LibSerialTest, testSerialStreamGetAvailableSerialPorts)
 {
     SCOPED_TRACE("Serial Stream GetAvailableSerialPorts() Test");
@@ -2424,6 +2536,16 @@ TEST_F(LibSerialTest, testSerialPortGetFileDescriptor)
     for (size_t i = 0; i < numberOfTestIterations; i++)
     {
         testSerialPortGetFileDescriptor();
+    }
+}
+
+TEST_F(LibSerialTest, testSerialPortGetNumberOfBytesAvailable)
+{
+    SCOPED_TRACE("Serial Port GetNumberOfBytesAvailable() Test");
+    
+    for (size_t i = 0; i < numberOfTestIterations; i++)
+    {
+        testSerialPortGetNumberOfBytesAvailable();
     }
 }
 

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -1529,12 +1529,9 @@ protected:
         try
         {
             serialPort1.Write(writeVector1);
-            serialPort2.Write(writeVector2);
 
             tcdrain(serialPort1.GetFileDescriptor());
-            tcdrain(serialPort2.GetFileDescriptor());
 
-            serialPort1.Read(readVector2, 0, 75);
             serialPort2.Read(readVector1, 0, 75);
         }
         catch(...)
@@ -1543,20 +1540,7 @@ protected:
         }
 
         ASSERT_TRUE(timeOutTestPass);
-
-        timeOutTestPass = false;
-
-        try
-        {
-            serialPort1.Read(readVector1, 1, 1);
-            serialPort2.Read(readVector2, 1, 1);
-        }
-        catch(ReadTimeout)
-        {
-            timeOutTestPass = true;
-        }
-        
-        ASSERT_TRUE(timeOutTestPass);
+        ASSERT_EQ(readVector1, writeVector1);
 
         serialPort1.Close();
         serialPort2.Close();
@@ -1587,18 +1571,6 @@ protected:
         ASSERT_EQ(readString1, writeString1);
         ASSERT_EQ(readString2, writeString2);
 
-        try
-        {
-            serialPort1.Read(readString1, writeString1.size(), 1);
-            serialPort2.Read(readString2, writeString2.size(), 1);
-        }
-        catch(ReadTimeout)
-        {
-            timeOutTestPass = true;
-        }
-        
-        ASSERT_TRUE(timeOutTestPass);
-        
         timeOutTestPass = false;
 
         readString1.clear();
@@ -1607,13 +1579,10 @@ protected:
         try
         {
             serialPort1.Write(writeString1);
-            serialPort2.Write(writeString2);
 
             tcdrain(serialPort1.GetFileDescriptor());
-            tcdrain(serialPort2.GetFileDescriptor());
 
             serialPort2.Read(readString1, 0, 75);
-            serialPort1.Read(readString2, 0, 75);
         }
         catch(...)
         {
@@ -1621,7 +1590,8 @@ protected:
         }
 
         ASSERT_TRUE(timeOutTestPass);
-
+        ASSERT_EQ(readString1, writeString1);
+        
         serialPort1.Close();
         serialPort2.Close();
         

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -2403,7 +2403,7 @@ TEST_F(LibSerialTest, testMultiThreadSerialStreamReadWrite)
     SCOPED_TRACE("Test Multi-Thread Serial Stream Communication.");
 
     std::cout << "Note: This test calls getline() which can block indefinitely "
-              << "should a newline character fail to be recieved." << std::endl;
+              << "if a newline character is not recieved." << std::endl;
 
     for (size_t i = 0; i < numberOfTestIterations; i++)
     {

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -379,7 +379,7 @@ protected:
         ASSERT_TRUE(serialStream1.IsOpen());
         ASSERT_TRUE(serialStream2.IsOpen());
 
-        for(const auto baud_rate: baudRates)
+        for (const auto baud_rate: baudRates)
         {
             serialStream1.SetBaudRate(baud_rate);
             serialStream2.SetBaudRate(baud_rate);
@@ -406,11 +406,13 @@ protected:
         ASSERT_TRUE(serialStream1.IsOpen());
         ASSERT_TRUE(serialStream2.IsOpen());
 
-        for(const auto char_size: characterSizes)
+        for (const auto char_size: characterSizes)
         {
             // @NOTE - Smaller Character Size values do not work in Linux.
-            if (char_size < CharacterSize::CHAR_SIZE_6)
-                continue ;
+            if (char_size < CharacterSize::CHAR_SIZE_7)
+            {
+                continue;
+            }
             
             serialStream1.SetCharacterSize(char_size);
             serialStream2.SetCharacterSize(char_size);
@@ -442,7 +444,7 @@ protected:
         FlowControl flowControl1 = FlowControl::FLOW_CONTROL_DEFAULT;
         FlowControl flowControl2 = FlowControl::FLOW_CONTROL_DEFAULT;
 
-        for(const auto flow_control: flowControlTypes)
+        for (const auto flow_control: flowControlTypes)
         {
             serialStream1.SetFlowControl(flow_control);
             serialStream1.SetFlowControl(flow_control);
@@ -472,7 +474,7 @@ protected:
         Parity parity1 = Parity::PARITY_DEFAULT;
         Parity parity2 = Parity::PARITY_DEFAULT;
 
-        for(const auto parity: parityTypes)
+        for (const auto parity: parityTypes)
         {
             serialStream1.SetParity(parity);
             serialStream2.SetParity(parity);
@@ -502,7 +504,7 @@ protected:
         StopBits numberOfStopBits1 = StopBits::STOP_BITS_DEFAULT;
         StopBits numberOfStopBits2 = StopBits::STOP_BITS_DEFAULT;
 
-        for(const auto stop_bits: stopBits)
+        for (const auto stop_bits: stopBits)
         {
             serialStream1.SetStopBits(stop_bits);
             serialStream2.SetStopBits(stop_bits);
@@ -1156,8 +1158,10 @@ protected:
         for(const auto char_size: characterSizes)
         {
             // @NOTE - Smaller CharSize values appear to be invalid on x86 Linux.
-            if (char_size < CharacterSize::CHAR_SIZE_6)
-                continue ;
+            if (char_size < CharacterSize::CHAR_SIZE_7)
+            {
+                continue;
+            }
 
             serialPort1.SetCharacterSize(char_size);
             serialPort2.SetCharacterSize(char_size);
@@ -1184,11 +1188,13 @@ protected:
         ASSERT_TRUE(serialPort1.IsOpen());
         ASSERT_TRUE(serialPort2.IsOpen());
 
-        for(const auto flow_control: flowControlTypes)
+        for (const auto flow_control: flowControlTypes)
         {
             // @NOTE - FLOW_CONTROL_SOFT flow control appears to be invalid on x86 Linux.
             if (flow_control == FlowControl::FLOW_CONTROL_SOFTWARE)
-                continue ;
+            {
+                continue;
+            }
 
             serialPort1.SetFlowControl(flow_control);
             serialPort2.SetFlowControl(flow_control);
@@ -1215,7 +1221,7 @@ protected:
         ASSERT_TRUE(serialPort1.IsOpen());
         ASSERT_TRUE(serialPort2.IsOpen());
 
-        for(const auto parity: parityTypes)
+        for (const auto parity: parityTypes)
         {
             serialPort1.SetParity(parity);
             serialPort2.SetParity(parity);
@@ -1242,7 +1248,7 @@ protected:
         ASSERT_TRUE(serialPort1.IsOpen());
         ASSERT_TRUE(serialPort2.IsOpen());
 
-        for(const auto stop_bits: stopBits)
+        for (const auto stop_bits: stopBits)
         {
             serialPort1.SetStopBits(stop_bits);
             serialPort2.SetStopBits(stop_bits);
@@ -1532,6 +1538,20 @@ protected:
 
         ASSERT_TRUE(timeOutTestPass);
 
+        timeOutTestPass = false;
+
+        try
+        {
+            serialPort1.Read(*readBuffer1, 0, 5);
+            serialPort2.Read(*readBuffer2, 0, 5);
+        }
+        catch(...)
+        {
+            timeOutTestPass = true;
+        }
+
+        ASSERT_TRUE(timeOutTestPass);
+
         serialPort1.Close();
         serialPort2.Close();
 
@@ -1589,6 +1609,20 @@ protected:
         }
         
         ASSERT_TRUE(timeOutTestPass);
+        
+        timeOutTestPass = false;
+
+        try
+        {
+            serialPort1.Read(readDataBuffer1, 0, 5);
+            serialPort2.Read(readDataBuffer2, 0, 5);
+        }
+        catch(...)
+        {
+            timeOutTestPass = true;
+        }
+
+        ASSERT_TRUE(timeOutTestPass);
 
         serialPort1.Close();
         serialPort2.Close();
@@ -1629,6 +1663,20 @@ protected:
             timeOutTestPass = true;
         }
         
+        ASSERT_TRUE(timeOutTestPass);
+        
+        timeOutTestPass = false;
+
+        try
+        {
+            serialPort1.Read(readString1, 0, 5);
+            serialPort2.Read(readString2, 0, 5);
+        }
+        catch(...)
+        {
+            timeOutTestPass = true;
+        }
+
         ASSERT_TRUE(timeOutTestPass);
 
         serialPort1.Close();


### PR DESCRIPTION
Hi CrayzeeWUlf,

This PR updates the SerialPort Class Read() methods to allow indefinite amount of data to be read before the timeout has elapsed. Unit tests and documentation has also been updated to describe and test those cases.

Please let me know if you have any questions!

-Mark