### PR TITLE
Make tests conditional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,11 @@
-SUBDIRS =  src test examples docs
+SUBDIRS =  src examples docs
 
 if PYTHON
 SUBDIRS += sip
+endif
+
+if TESTS
+SUBDIRS += test
 endif
 
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,11 @@ AC_ARG_WITH([python],
 	[], [with_python=yes])
 AM_CONDITIONAL([PYTHON], [test "${with_python}" != "no"])
 
+AC_ARG_ENABLE([tests],
+	AS_HELP_STRING([--disable-tests], [Disable tests]),
+	[], [enable_tests=yes])
+AM_CONDITIONAL([TESTS], [test "${enable_tests}" != "no"])
+
 AC_OUTPUT([Makefile
 doxygen.conf
 libserial.spec


### PR DESCRIPTION
test uses gtest so allow the user to disable tests to avoid adding a
unneeded dependency

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>