### PR TITLE
Break apart UnitTests.cpp to utilize a header file

### DIFF
--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -26,6 +26,9 @@
 
 #include <memory>
 
+/**
+ * @namespace Libserial
+ */
 namespace LibSerial 
 {
     /**

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- *   @file LibSerialTest.cpp                                                  *
+ *   @file UnitTest.cpp                                                       *
  *   @copyright (C) 2016 LibSerial Development Team                           *
  *                                                                            *
  *   This program is free software; you can redistribute it and/or modify     *
@@ -55,13 +55,13 @@ LibSerialTest::LibSerialTest()
     , writeString1("Quidquid latine dictum sit, altum sonatur. (Whatever is said in Latin sounds profound.)")
     , writeString2("The secret of the man who is universally interesting is that he is universally interested. - William Dean Howells")
 {
-    /* Empty */
+    // Empty
 }
 
 
 LibSerialTest::~LibSerialTest()
 {
-    /* Empty */
+    // Empty
 }
 
 void

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -27,2110 +27,2159 @@
 #include <unistd.h>
 #include <vector>
 
-#include <SerialPort.h>
-#include <SerialStream.h>
-
-// Default Serial Ports.
-#define TEST_SERIAL_PORT_1 "/dev/ttyUSB0"
-#define TEST_SERIAL_PORT_2 "/dev/ttyUSB1"
+#include "UnitTests.h"
 
 using namespace LibSerial;
 
-class LibSerialTest
-    : public ::testing::Test
+LibSerialTest::LibSerialTest()
+    : numberOfTestIterations(10)
+    , mutex{}
+    , entryTime(0)
+    , currentTime(0)
+    , elapsedTime(0)
+    , failureRate(0)
+    , loopCount(0)
+    , timeOutMilliseconds(250)   // 250ms timeout
+    , readBufferDelay(20000)     // 20ms delay
+    , baudRates{}
+    , characterSizes{}
+    , flowControlTypes{}
+    , parityTypes{}
+    , stopBits{}
+    , serialStream1{}
+    , serialStream2{}
+    , serialPort1{}
+    , serialPort2{}
+    , readString1("")
+    , readString2("")
+    , writeString1("Quidquid latine dictum sit, altum sonatur. (Whatever is said in Latin sounds profound.)")
+    , writeString2("The secret of the man who is universally interesting is that he is universally interested. - William Dean Howells")
 {
-public:
-    
-    size_t numberOfTestIterations = 10;
-
-protected:
-
-    std::mutex mutex;
-
-    size_t entryTime = 0;
-    size_t currentTime = 0;
-    size_t elapsedTime = 0;
-
-    size_t failureRate = 0;
-    size_t loopCount = 0;
-    size_t timeOutMilliseconds = 250;
-
-    unsigned int readBufferDelay = 20000; // 20ms delay
-
-    std::vector<BaudRate>        baudRates;
-    std::vector<CharacterSize>   characterSizes;
-    std::vector<FlowControl>     flowControlTypes;
-    std::vector<Parity>          parityTypes;
-    std::vector<StopBits>        stopBits;
-
-    SerialStream serialStream1;
-    SerialStream serialStream2;
-
-    SerialPort serialPort1;
-    SerialPort serialPort2;
-
-    std::string readString1  = "";
-    std::string writeString1 = "Quidquid latine dictum sit, altum sonatur. (Whatever is said in Latin sounds profound.)";
-
-    std::string readString2  = "";
-    std::string writeString2 = "The secret of the man who is universally interesting is that he is universally interested. - William Dean Howells";
-
-    virtual void SetUp()
-    {
-        // Any additional setup steps can be performed here.
-    }
-
-    size_t getTimeInMilliSeconds()
-    {
-        std::chrono::high_resolution_clock::duration timeNow = 
-            std::chrono::high_resolution_clock::now().time_since_epoch();
-
-        return std::chrono::duration_cast<std::chrono::milliseconds>(timeNow).count();
-    }
-    
-    size_t getTimeInMicroSeconds()
-    {
-        std::chrono::high_resolution_clock::duration timeNow = 
-            std::chrono::high_resolution_clock::now().time_since_epoch();
-
-        return std::chrono::duration_cast<std::chrono::microseconds>(timeNow).count();
-    }
-
-
-    //---------------------- Serial Stream Unit Tests -----------------------//
-
-    void testSerialStreamConstructors()
-    {
-        SerialStream serialStream3(TEST_SERIAL_PORT_1);
-        SerialStream serialStream4(TEST_SERIAL_PORT_2,
-                                   BaudRate::BAUD_9600,
-                                   CharacterSize::CHAR_SIZE_7,
-                                   FlowControl::FLOW_CONTROL_HARDWARE,
-                                   Parity::PARITY_EVEN,
-                                   StopBits::STOP_BITS_2);
-
-        ASSERT_TRUE(serialStream3.IsOpen());
-        ASSERT_TRUE(serialStream4.IsOpen());
-        
-        ASSERT_EQ(serialStream4.GetBaudRate(),      BaudRate::BAUD_9600);
-        ASSERT_EQ(serialStream4.GetCharacterSize(), CharacterSize::CHAR_SIZE_7);
-        ASSERT_EQ(serialStream4.GetFlowControl(),   FlowControl::FLOW_CONTROL_HARDWARE);
-        ASSERT_EQ(serialStream4.GetParity(),        Parity::PARITY_EVEN);
-        ASSERT_EQ(serialStream4.GetStopBits(),      StopBits::STOP_BITS_2);
-        
-        serialStream3.Close();
-        serialStream4.Close();
-
-        ASSERT_FALSE(serialStream3.IsOpen());
-        ASSERT_FALSE(serialStream4.IsOpen());
-    }
-
-    void testSerialStreamOpenClose()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        SerialStream serialStream3;
-        SerialStream serialStream4;
-
-        ASSERT_FALSE(serialStream3.IsOpen());
-        ASSERT_FALSE(serialStream4.IsOpen());
-
-        bool exclusiveUseTestPass = false;
-
-        try
-        {
-            serialStream3.Open(TEST_SERIAL_PORT_1);
-            serialStream4.Open(TEST_SERIAL_PORT_2);
-        }
-        catch (...)
-        {
-            exclusiveUseTestPass = true;
-        }
-
-        ASSERT_TRUE(exclusiveUseTestPass);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamDrainWriteBuffer()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1.FlushIOBuffers();
-        serialStream2.FlushIOBuffers();
-
-        serialStream1 << writeString1 << std::endl;
-        serialStream2 << writeString2 << std::endl;
-
-        serialStream1.DrainWriteBuffer();
-        serialStream2.DrainWriteBuffer();
-
-        // Allow time for the read buffers to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialStream1.IsDataAvailable());
-        ASSERT_TRUE(serialStream2.IsDataAvailable());
-
-        serialStream1.FlushIOBuffers();
-        serialStream2.FlushIOBuffers();
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamFlushInputBuffer()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1.FlushInputBuffer();
-        serialStream2.FlushInputBuffer();
-
-        ASSERT_FALSE(serialStream1.IsDataAvailable());
-        ASSERT_FALSE(serialStream2.IsDataAvailable());
-
-        char writeByte = 'A';
-
-        serialStream1.write(&writeByte, 1);
-        serialStream2.write(&writeByte, 1);
-
-        serialStream1.DrainWriteBuffer();
-        serialStream2.DrainWriteBuffer();
-
-        // Allow time for the read buffers to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialStream1.IsDataAvailable());
-        ASSERT_TRUE(serialStream2.IsDataAvailable());
-
-        serialStream1.FlushInputBuffer();
-        serialStream2.FlushInputBuffer();
-
-        ASSERT_FALSE(serialStream1.IsDataAvailable());
-        ASSERT_FALSE(serialStream2.IsDataAvailable());
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamFlushOutputBuffer()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1.FlushInputBuffer();
-        serialStream2.FlushInputBuffer();
-
-        ASSERT_FALSE(serialStream1.IsDataAvailable());
-        ASSERT_FALSE(serialStream2.IsDataAvailable());
-
-        char writeByte = 'A';
-
-        serialStream1.write(&writeByte, 1);
-        serialStream1.FlushOutputBuffer();
-
-        serialStream2.write(&writeByte, 1);
-        serialStream2.FlushOutputBuffer();
-
-        ASSERT_FALSE(serialStream1.IsDataAvailable());
-        ASSERT_FALSE(serialStream2.IsDataAvailable());
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamFlushIOBuffers()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        char writeByte = 'a';
-
-        serialStream1.write(&writeByte, 1);
-        serialStream1.FlushIOBuffers();
-
-        ASSERT_FALSE(serialStream2.IsDataAvailable());
-
-        serialStream2.write(&writeByte, 1);
-        serialStream2.FlushIOBuffers();
-
-        ASSERT_FALSE(serialStream1.IsDataAvailable());
-
-        serialStream1.write(&writeByte, 1);
-        serialStream2.write(&writeByte, 1);
-
-        serialStream1.DrainWriteBuffer();
-        serialStream2.DrainWriteBuffer();
-        
-        // Allow time for the read buffers to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialStream1.IsDataAvailable());
-        ASSERT_TRUE(serialStream2.IsDataAvailable());
-
-        serialStream1.FlushIOBuffers();
-        serialStream2.FlushIOBuffers();
-
-        ASSERT_FALSE(serialStream1.IsDataAvailable());
-        ASSERT_FALSE(serialStream2.IsDataAvailable());
-
-        serialStream1.Close();
-        serialStream2.Close();
-        
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamIsDataAvailableTest()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        ASSERT_FALSE(serialStream1.IsDataAvailable());
-        ASSERT_FALSE(serialStream2.IsDataAvailable());
-
-        char writeByte = 'a';
-        char readByte = 'b';
-
-        serialStream1.write(&writeByte, 1);
-        serialStream1.DrainWriteBuffer();
-
-        // Allow time for the read buffer to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialStream2.IsDataAvailable());
-
-        serialStream2.read(&readByte, 1);
-        ASSERT_EQ(readByte, writeByte);
-
-        serialStream2.write(&writeByte, 1);
-        serialStream2.DrainWriteBuffer();
-
-        // Allow time for the read buffer to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialStream1.IsDataAvailable());
-
-        serialStream1.read(&readByte, 1);
-        ASSERT_EQ(readByte, writeByte);
-
-        ASSERT_FALSE(serialStream1.IsDataAvailable());
-        ASSERT_FALSE(serialStream2.IsDataAvailable());
-
-        serialStream1.Close();
-        serialStream2.Close();
-        
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamIsOpenTest()
-    {
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetBaudRate()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        for (const auto baud_rate: baudRates)
-        {
-            serialStream1.SetBaudRate(baud_rate);
-            serialStream2.SetBaudRate(baud_rate);
-
-            const auto baudRate1 = serialStream1.GetBaudRate();
-            const auto baudRate2 = serialStream2.GetBaudRate();
-
-            ASSERT_EQ(baudRate1, baud_rate);
-            ASSERT_EQ(baudRate2, baud_rate);
-        }
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetCharacterSize()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        for (const auto char_size: characterSizes)
-        {
-            // @NOTE - Smaller Character Size values do not work in Linux.
-            if (char_size < CharacterSize::CHAR_SIZE_7)
-            {
-                continue;
-            }
-            
-            serialStream1.SetCharacterSize(char_size);
-            serialStream2.SetCharacterSize(char_size);
-
-            const auto characterSize1 = serialStream1.GetCharacterSize();
-            const auto characterSize2 = serialStream2.GetCharacterSize();
-
-            ASSERT_EQ(characterSize1, char_size);
-            ASSERT_EQ(characterSize2, char_size);
-        }
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetFlowControl()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        for (const auto flow_control: flowControlTypes)
-        {
-            serialStream1.SetFlowControl(flow_control);
-            serialStream1.SetFlowControl(flow_control);
-
-            const auto flowControl1 = serialStream1.GetFlowControl();
-            const auto flowControl2 = serialStream1.GetFlowControl();
-
-            ASSERT_EQ(flowControl1, flow_control);
-            ASSERT_EQ(flowControl2, flow_control);
-        }
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetParity()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        for (const auto parity: parityTypes)
-        {
-            serialStream1.SetParity(parity);
-            serialStream2.SetParity(parity);
-
-            const auto parity1 = serialStream1.GetParity();
-            const auto parity2 = serialStream2.GetParity();
-
-            ASSERT_EQ(parity1, parity);
-            ASSERT_EQ(parity2, parity);
-        }
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetStopBits()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        for (const auto stop_bits: stopBits)
-        {
-            serialStream1.SetStopBits(stop_bits);
-            serialStream2.SetStopBits(stop_bits);
-
-            const auto numberOfStopBits1 = serialStream1.GetStopBits();
-            const auto numberOfStopBits2 = serialStream2.GetStopBits();
-
-            ASSERT_EQ(numberOfStopBits1, stop_bits);
-            ASSERT_EQ(numberOfStopBits2, stop_bits);
-        }
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetVMin()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        short vMin1 = 0;
-        short vMin2 = 0;
-
-        for (short i = 0; i < 5; i++)
-        {
-            serialStream1.SetVMin(i);
-            serialStream2.SetVMin(i);
-
-            vMin1 = serialStream1.GetVMin();
-            vMin2 = serialStream2.GetVMin();
-
-            ASSERT_EQ(vMin1, i);
-            ASSERT_EQ(vMin2, i);
-        }
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetVTime()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        short vTime1 = 0;
-        short vTime2 = 0;
-
-        for (short i = 0; i < 5; i++)
-        {
-            serialStream1.SetVTime(i);
-            serialStream2.SetVTime(i);
-
-            vTime1 = serialStream1.GetVTime();
-            vTime2 = serialStream2.GetVTime();
-
-            ASSERT_EQ(vTime1, i);
-            ASSERT_EQ(vTime2, i);
-        }
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetDTR()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-        serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        bool dtrLine1 = false;
-        bool dtrLine2 = false;
-
-        dtrLine1 = serialStream1.GetDTR();
-        dtrLine2 = serialStream2.GetDTR();
-
-        ASSERT_TRUE(dtrLine1);
-        ASSERT_TRUE(dtrLine2);
-
-        serialStream1.SetDTR(true);
-        serialStream2.SetDTR(true);
-
-        dtrLine1 = serialStream1.GetDTR();
-        dtrLine2 = serialStream2.GetDTR();
-
-        ASSERT_TRUE(dtrLine1);
-        ASSERT_TRUE(dtrLine2);
-
-        serialStream1.SetDTR(false);
-        serialStream2.SetDTR(false);
-
-        dtrLine1 = serialStream1.GetDTR();
-        dtrLine2 = serialStream2.GetDTR();
-
-        ASSERT_FALSE(dtrLine1);
-        ASSERT_FALSE(dtrLine2);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetGetRTS()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-        serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        bool rtsLine1 = false;
-        bool rtsLine2 = false;
-
-        rtsLine1 = serialStream1.GetRTS();
-        rtsLine2 = serialStream2.GetRTS();
-        
-        ASSERT_TRUE(rtsLine1);
-        ASSERT_TRUE(rtsLine2);
-
-        serialStream1.SetRTS(false);
-        serialStream2.SetRTS(false);
-        
-        rtsLine1 = serialStream1.GetRTS();
-        rtsLine2 = serialStream2.GetRTS();
-        
-        ASSERT_FALSE(rtsLine1);
-        ASSERT_FALSE(rtsLine2);
-
-        serialStream1.SetRTS(true);
-        serialStream2.SetRTS(true);
-
-        rtsLine1 = serialStream1.GetRTS();
-        rtsLine2 = serialStream2.GetRTS();
-
-        ASSERT_TRUE(rtsLine1);
-        ASSERT_TRUE(rtsLine2);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetRTSGetCTS()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-        serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        bool ctsLine1 = false;
-        bool ctsLine2 = false;
-
-        ctsLine1 = serialStream1.GetCTS();
-        ctsLine2 = serialStream2.GetCTS();
-
-        ASSERT_TRUE(ctsLine1);
-        ASSERT_TRUE(ctsLine2);
-
-        serialStream1.SetRTS(false);
-        serialStream2.SetRTS(false);
-
-        ctsLine1 = serialStream1.GetCTS();
-        ctsLine2 = serialStream2.GetCTS();
-
-        ASSERT_FALSE(ctsLine1);
-        ASSERT_FALSE(ctsLine2);
-
-        serialStream1.SetRTS(true);
-        serialStream2.SetRTS(true);
-
-        ctsLine1 = serialStream1.GetCTS();
-        ctsLine2 = serialStream2.GetCTS();
-
-        ASSERT_TRUE(ctsLine1);
-        ASSERT_TRUE(ctsLine2);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamSetDTRGetDSR()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-        serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        bool dsrStatus1 = false;
-        bool dsrStatus2 = false;
-
-        dsrStatus1 = serialStream1.GetDSR();
-        dsrStatus2 = serialStream2.GetDSR();
-
-        ASSERT_TRUE(dsrStatus1);
-        ASSERT_TRUE(dsrStatus2);
-
-        serialStream1.SetDTR(false);
-        serialStream2.SetDTR(false);
-
-        dsrStatus1 = serialStream1.GetDSR();
-        dsrStatus2 = serialStream2.GetDSR();
-
-        ASSERT_FALSE(dsrStatus1);
-        ASSERT_FALSE(dsrStatus2);
-
-        serialStream1.SetDTR(true);
-        serialStream2.SetDTR(true);
-
-        dsrStatus1 = serialStream1.GetDSR();
-        dsrStatus2 = serialStream2.GetDSR();
-
-        ASSERT_TRUE(dsrStatus1);
-        ASSERT_TRUE(dsrStatus2);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamGetFileDescriptor()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        int fileDescriptor1 = serialStream1.GetFileDescriptor();
-        int fileDescriptor2 = serialStream2.GetFileDescriptor();
-
-        ASSERT_GT(fileDescriptor1, 0);
-        ASSERT_GT(fileDescriptor2, 0);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamGetNumberOfBytesAvailable()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        char writeByte1 = 'a';
-        char writeByte2 = 'A';
-
-        char readByte1  = 'b';
-        char readByte2  = 'B';
-
-        int bytesAvailable1 = 0;
-        int bytesAvailable2 = 0;
-
-        serialStream1.write(&writeByte1, 1);
-        serialStream2.write(&writeByte2, 1);
-
-        serialStream1.DrainWriteBuffer();
-        serialStream2.DrainWriteBuffer();
-
-        usleep(readBufferDelay);
-
-        bytesAvailable1 = serialStream1.GetNumberOfBytesAvailable();
-        bytesAvailable2 = serialStream2.GetNumberOfBytesAvailable();
-
-        ASSERT_EQ(bytesAvailable1, 1);
-        ASSERT_EQ(bytesAvailable2, 1);
-
-        serialStream1.read(&readByte2, 1);
-        serialStream2.read(&readByte1, 1);
-
-        bytesAvailable1 = serialStream1.GetNumberOfBytesAvailable();
-        bytesAvailable2 = serialStream2.GetNumberOfBytesAvailable();
-
-        ASSERT_EQ(bytesAvailable1, 0);
-        ASSERT_EQ(bytesAvailable2, 0);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamGetAvailableSerialPorts()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        std::vector<std::string> serialPorts1;
-        std::vector<std::string> serialPorts2;
- 
-        serialPorts1.clear();
-        serialPorts2.clear();
- 
-        serialPorts1 = serialStream1.GetAvailableSerialPorts();
-        serialPorts2 = serialStream2.GetAvailableSerialPorts();
- 
-        int portCount1 = (int)serialPorts1.size();
-        int portCount2 = (int)serialPorts2.size();
-
-        ASSERT_GE(portCount1, 2);
-        ASSERT_GE(portCount2, 2);
-        ASSERT_EQ(portCount1, portCount2);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamReadByteWriteByte()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        char writeByte1 = 'a';
-        char writeByte2 = 'A';
-
-        char readByte1  = 'b';
-        char readByte2  = 'B';
-
-        serialStream1.write(&writeByte1, 1);
-        serialStream2.write(&writeByte2, 1);
-
-        serialStream1.read(&readByte2, 1);
-        serialStream2.read(&readByte1, 1);
-
-        ASSERT_EQ(readByte1, writeByte1);
-        ASSERT_EQ(readByte2, writeByte2);
-
-        serialStream1 << writeByte1;
-        serialStream2 << writeByte2;
-
-        serialStream1.read(&readByte2, 1);
-        serialStream2.read(&readByte1, 1);
-
-        ASSERT_EQ(readByte1, writeByte1);
-        ASSERT_EQ(readByte2, writeByte2);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamGetLineWriteString()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        serialStream1 << writeString1 << std::endl;
-        serialStream2 << writeString2 << std::endl;
-
-        getline(serialStream1, readString2);
-        getline(serialStream2, readString1);
-
-        ASSERT_EQ(readString1, writeString1);
-        ASSERT_EQ(readString2, writeString2);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-    void testSerialStreamGetWriteByte()
-    {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialStream1.IsOpen());
-        ASSERT_TRUE(serialStream2.IsOpen());
-
-        char writeByte1 = 'a';
-        char writeByte2 = 'A';
-
-        char readByte1  = 'b';
-        char readByte2  = 'B';
-
-        serialStream1.write(&writeByte1, 1);
-        serialStream2.write(&writeByte2, 1);
-
-        serialStream1.get(readByte2);
-        serialStream2.get(readByte1);
-
-        ASSERT_EQ(readByte1, writeByte1);
-        ASSERT_EQ(readByte2, writeByte2);
-
-        serialStream1 << writeByte1;
-        serialStream2 << writeByte2;
-
-        serialStream1.get(readByte2);
-        serialStream2.get(readByte1);
-
-        ASSERT_EQ(readByte1, writeByte1);
-        ASSERT_EQ(readByte2, writeByte2);
-
-        serialStream1.Close();
-        serialStream2.Close();
-
-        ASSERT_FALSE(serialStream1.IsOpen());
-        ASSERT_FALSE(serialStream2.IsOpen());
-    }
-
-
-    //----------------------- Serial Port Unit Tests ------------------------//
-
-    void testSerialPortConstructors()
-    {
-        SerialPort serialPort3(TEST_SERIAL_PORT_1);
-        SerialPort serialPort4(TEST_SERIAL_PORT_2,
+    /* Empty */
+}
+
+
+LibSerialTest::~LibSerialTest()
+{
+    /* Empty */
+}
+
+void
+LibSerialTest::SetUp()
+{
+    // Any additional setup steps can be performed here.
+}
+
+size_t
+LibSerialTest::getTimeInMilliSeconds()
+{
+    std::chrono::high_resolution_clock::duration timeNow = 
+        std::chrono::high_resolution_clock::now().time_since_epoch();
+
+    return std::chrono::duration_cast<std::chrono::milliseconds>(timeNow).count();
+}
+
+size_t
+LibSerialTest::getTimeInMicroSeconds()
+{
+    std::chrono::high_resolution_clock::duration timeNow = 
+        std::chrono::high_resolution_clock::now().time_since_epoch();
+
+    return std::chrono::duration_cast<std::chrono::microseconds>(timeNow).count();
+}
+
+
+//---------------------- Serial Stream Unit Tests -----------------------//
+
+void
+LibSerialTest::testSerialStreamConstructors()
+{
+    SerialStream serialStream3(TEST_SERIAL_PORT_1);
+    SerialStream serialStream4(TEST_SERIAL_PORT_2,
                                BaudRate::BAUD_9600,
                                CharacterSize::CHAR_SIZE_7,
                                FlowControl::FLOW_CONTROL_HARDWARE,
                                Parity::PARITY_EVEN,
                                StopBits::STOP_BITS_2);
 
-        ASSERT_TRUE(serialPort3.IsOpen());
-        ASSERT_TRUE(serialPort4.IsOpen());
-        
-        ASSERT_EQ(serialPort4.GetBaudRate(),      BaudRate::BAUD_9600);
-        ASSERT_EQ(serialPort4.GetCharacterSize(), CharacterSize::CHAR_SIZE_7);
-        ASSERT_EQ(serialPort4.GetFlowControl(),   FlowControl::FLOW_CONTROL_HARDWARE);
-        ASSERT_EQ(serialPort4.GetParity(),        Parity::PARITY_EVEN);
-        ASSERT_EQ(serialPort4.GetStopBits(),      StopBits::STOP_BITS_2);
-        
-        serialPort3.Close();
-        serialPort4.Close();
+    ASSERT_TRUE(serialStream3.IsOpen());
+    ASSERT_TRUE(serialStream4.IsOpen());
+    
+    ASSERT_EQ(serialStream4.GetBaudRate(),      BaudRate::BAUD_9600);
+    ASSERT_EQ(serialStream4.GetCharacterSize(), CharacterSize::CHAR_SIZE_7);
+    ASSERT_EQ(serialStream4.GetFlowControl(),   FlowControl::FLOW_CONTROL_HARDWARE);
+    ASSERT_EQ(serialStream4.GetParity(),        Parity::PARITY_EVEN);
+    ASSERT_EQ(serialStream4.GetStopBits(),      StopBits::STOP_BITS_2);
+    
+    serialStream3.Close();
+    serialStream4.Close();
 
-        ASSERT_FALSE(serialPort3.IsOpen());
-        ASSERT_FALSE(serialPort4.IsOpen());
+    ASSERT_FALSE(serialStream3.IsOpen());
+    ASSERT_FALSE(serialStream4.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamOpenClose()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    SerialStream serialStream3;
+    SerialStream serialStream4;
+
+    ASSERT_FALSE(serialStream3.IsOpen());
+    ASSERT_FALSE(serialStream4.IsOpen());
+
+    bool exclusiveUseTestPass = false;
+
+    try
+    {
+        serialStream3.Open(TEST_SERIAL_PORT_1);
+        serialStream4.Open(TEST_SERIAL_PORT_2);
+    }
+    catch (...)
+    {
+        exclusiveUseTestPass = true;
     }
 
-    void testSerialPortOpenClose()
+    ASSERT_TRUE(exclusiveUseTestPass);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamDrainWriteBuffer()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1.FlushIOBuffers();
+    serialStream2.FlushIOBuffers();
+
+    serialStream1 << writeString1 << std::endl;
+    serialStream2 << writeString2 << std::endl;
+
+    serialStream1.DrainWriteBuffer();
+    serialStream2.DrainWriteBuffer();
+
+    // Allow time for the read buffers to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialStream1.IsDataAvailable());
+    ASSERT_TRUE(serialStream2.IsDataAvailable());
+
+    serialStream1.FlushIOBuffers();
+    serialStream2.FlushIOBuffers();
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamFlushInputBuffer()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1.FlushInputBuffer();
+    serialStream2.FlushInputBuffer();
+
+    ASSERT_FALSE(serialStream1.IsDataAvailable());
+    ASSERT_FALSE(serialStream2.IsDataAvailable());
+
+    char writeByte = 'A';
+
+    serialStream1.write(&writeByte, 1);
+    serialStream2.write(&writeByte, 1);
+
+    serialStream1.DrainWriteBuffer();
+    serialStream2.DrainWriteBuffer();
+
+    // Allow time for the read buffers to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialStream1.IsDataAvailable());
+    ASSERT_TRUE(serialStream2.IsDataAvailable());
+
+    serialStream1.FlushInputBuffer();
+    serialStream2.FlushInputBuffer();
+
+    ASSERT_FALSE(serialStream1.IsDataAvailable());
+    ASSERT_FALSE(serialStream2.IsDataAvailable());
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamFlushOutputBuffer()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1.FlushInputBuffer();
+    serialStream2.FlushInputBuffer();
+
+    ASSERT_FALSE(serialStream1.IsDataAvailable());
+    ASSERT_FALSE(serialStream2.IsDataAvailable());
+
+    char writeByte = 'A';
+
+    serialStream1.write(&writeByte, 1);
+    serialStream1.FlushOutputBuffer();
+
+    serialStream2.write(&writeByte, 1);
+    serialStream2.FlushOutputBuffer();
+
+    ASSERT_FALSE(serialStream1.IsDataAvailable());
+    ASSERT_FALSE(serialStream2.IsDataAvailable());
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamFlushIOBuffers()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    char writeByte = 'a';
+
+    serialStream1.write(&writeByte, 1);
+    serialStream1.FlushIOBuffers();
+
+    ASSERT_FALSE(serialStream2.IsDataAvailable());
+
+    serialStream2.write(&writeByte, 1);
+    serialStream2.FlushIOBuffers();
+
+    ASSERT_FALSE(serialStream1.IsDataAvailable());
+
+    serialStream1.write(&writeByte, 1);
+    serialStream2.write(&writeByte, 1);
+
+    serialStream1.DrainWriteBuffer();
+    serialStream2.DrainWriteBuffer();
+    
+    // Allow time for the read buffers to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialStream1.IsDataAvailable());
+    ASSERT_TRUE(serialStream2.IsDataAvailable());
+
+    serialStream1.FlushIOBuffers();
+    serialStream2.FlushIOBuffers();
+
+    ASSERT_FALSE(serialStream1.IsDataAvailable());
+    ASSERT_FALSE(serialStream2.IsDataAvailable());
+
+    serialStream1.Close();
+    serialStream2.Close();
+    
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamIsDataAvailableTest()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    ASSERT_FALSE(serialStream1.IsDataAvailable());
+    ASSERT_FALSE(serialStream2.IsDataAvailable());
+
+    char writeByte = 'a';
+    char readByte = 'b';
+
+    serialStream1.write(&writeByte, 1);
+    serialStream1.DrainWriteBuffer();
+
+    // Allow time for the read buffer to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialStream2.IsDataAvailable());
+
+    serialStream2.read(&readByte, 1);
+    ASSERT_EQ(readByte, writeByte);
+
+    serialStream2.write(&writeByte, 1);
+    serialStream2.DrainWriteBuffer();
+
+    // Allow time for the read buffer to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialStream1.IsDataAvailable());
+
+    serialStream1.read(&readByte, 1);
+    ASSERT_EQ(readByte, writeByte);
+
+    ASSERT_FALSE(serialStream1.IsDataAvailable());
+    ASSERT_FALSE(serialStream2.IsDataAvailable());
+
+    serialStream1.Close();
+    serialStream2.Close();
+    
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamIsOpenTest()
+{
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetBaudRate()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    for (const auto baud_rate: baudRates)
     {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        SerialPort serialPort3;
-        SerialPort serialPort4;
-
-        ASSERT_FALSE(serialPort3.IsOpen());
-        ASSERT_FALSE(serialPort4.IsOpen());
-
-        bool exclusiveUseTestPass = false;
-
-        try
-        {
-            serialPort3.Open(TEST_SERIAL_PORT_1);
-            serialPort4.Open(TEST_SERIAL_PORT_2);
-        }
-        catch (...)
-        {
-            exclusiveUseTestPass = true;
-        }
-
-        ASSERT_TRUE(exclusiveUseTestPass);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortDrainWriteBuffer()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        serialPort1.FlushIOBuffers();
-        serialPort2.FlushIOBuffers();
-
-        serialPort1.Write(writeString1);
-        serialPort2.Write(writeString2);
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        serialPort1.DrainWriteBuffer();
-        serialPort2.DrainWriteBuffer();
-
-        // Allow time for the read buffers to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialPort1.IsDataAvailable());
-        ASSERT_TRUE(serialPort2.IsDataAvailable());
-
-        serialPort1.FlushIOBuffers();
-        serialPort2.FlushIOBuffers();
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortFlushInputBuffer()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        serialPort1.FlushInputBuffer();
-        serialPort2.FlushInputBuffer();
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        char writeByte = 'A';
-
-        serialPort1.WriteByte(writeByte);
-        serialPort2.WriteByte(writeByte);
-
-        serialPort1.DrainWriteBuffer();
-        serialPort2.DrainWriteBuffer();
-
-        // Allow time for the read buffers to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialPort1.IsDataAvailable());
-        ASSERT_TRUE(serialPort2.IsDataAvailable());
-
-        serialPort1.FlushInputBuffer();
-        serialPort2.FlushInputBuffer();
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortFlushOutputBuffer()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        serialPort1.FlushInputBuffer();
-        serialPort2.FlushInputBuffer();
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        char writeByte = 'A';
-        
-        serialPort1.WriteByte(writeByte);
-        serialPort1.FlushOutputBuffer();
-
-        serialPort2.WriteByte(writeByte);
-        serialPort2.FlushOutputBuffer();
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        serialPort1.Close();
-        serialPort2.Close();
-        
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortFlushIOBuffers()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        char writeByte = 'a';
-
-        serialPort1.WriteByte(writeByte);
-        serialPort1.FlushIOBuffers();
-
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        serialPort2.WriteByte(writeByte);
-        serialPort2.FlushIOBuffers();
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-
-        serialPort1.WriteByte(writeByte);
-        serialPort2.WriteByte(writeByte);
-
-        serialPort1.DrainWriteBuffer();
-        serialPort2.DrainWriteBuffer();
-        
-        // Allow time for the read buffers to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialPort1.IsDataAvailable());
-        ASSERT_TRUE(serialPort2.IsDataAvailable());
-
-        serialPort1.FlushIOBuffers();
-        serialPort2.FlushIOBuffers();
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortIsDataAvailableTest()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        char writeByte = 'a';
-        char readByte = 'b';
-
-        serialPort1.WriteByte(writeByte);
-        serialPort1.DrainWriteBuffer();
-
-        // Allow time for the read buffer to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialPort2.IsDataAvailable());
-
-        serialPort2.ReadByte(readByte, 1);
-        ASSERT_EQ(readByte, writeByte);
-
-        serialPort2.WriteByte(writeByte);
-        serialPort2.DrainWriteBuffer();
-
-        // Allow time for the read buffer to show that data is available.
-        usleep(readBufferDelay);
-
-        ASSERT_TRUE(serialPort1.IsDataAvailable());
-
-        serialPort1.ReadByte(readByte, 1);
-        ASSERT_EQ(readByte, writeByte);
-
-        ASSERT_FALSE(serialPort1.IsDataAvailable());
-        ASSERT_FALSE(serialPort2.IsDataAvailable());
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortIsOpenTest()
-    {
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetGetBaudRate()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        for(const auto baud_rate: baudRates)
-        {
-            serialPort1.SetBaudRate(baud_rate);
-            serialPort2.SetBaudRate(baud_rate);
-
-            const auto baudRate1 = serialPort1.GetBaudRate();
-            const auto baudRate2 = serialPort1.GetBaudRate();
-
-            ASSERT_EQ(baudRate1, baud_rate);
-            ASSERT_EQ(baudRate2, baud_rate);
-        }
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetGetCharacterSize()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        for(const auto char_size: characterSizes)
-        {
-            // @NOTE - Smaller CharSize values appear to be invalid on x86 Linux.
-            if (char_size < CharacterSize::CHAR_SIZE_7)
-            {
-                continue;
-            }
-
-            serialPort1.SetCharacterSize(char_size);
-            serialPort2.SetCharacterSize(char_size);
-
-            const auto characterSize1 = serialPort1.GetCharacterSize();
-            const auto characterSize2 = serialPort2.GetCharacterSize();
-
-            ASSERT_EQ(characterSize1, char_size);
-            ASSERT_EQ(characterSize2, char_size);
-        }
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetGetFlowControl()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        for (const auto flow_control: flowControlTypes)
-        {
-            // @NOTE - FLOW_CONTROL_SOFT flow control appears to be invalid on x86 Linux.
-            if (flow_control == FlowControl::FLOW_CONTROL_SOFTWARE)
-            {
-                continue;
-            }
-
-            serialPort1.SetFlowControl(flow_control);
-            serialPort2.SetFlowControl(flow_control);
-
-            const auto flowControl1 = serialPort1.GetFlowControl();
-            const auto flowControl2 = serialPort2.GetFlowControl();
-
-            ASSERT_EQ(flowControl1, flow_control);
-            ASSERT_EQ(flowControl2, flow_control);
-        }
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetGetParity()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        for (const auto parity: parityTypes)
-        {
-            serialPort1.SetParity(parity);
-            serialPort2.SetParity(parity);
-
-            const auto parity1 = serialPort1.GetParity();
-            const auto parity2 = serialPort2.GetParity();
-
-            ASSERT_EQ(parity1, parity);
-            ASSERT_EQ(parity2, parity);
-        }
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetGetStopBits()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        for (const auto stop_bits: stopBits)
-        {
-            serialPort1.SetStopBits(stop_bits);
-            serialPort2.SetStopBits(stop_bits);
-
-            const auto stopBits1 = serialPort1.GetStopBits();
-            const auto stopBits2 = serialPort2.GetStopBits();
-
-            ASSERT_EQ(stopBits1, stop_bits);
-            ASSERT_EQ(stopBits2, stop_bits);
-        }
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetGetVMin()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        ASSERT_TRUE(serialPort1.IsOpen());
-
-        for (short i = 0; i < 5; i++)
-        {
-            serialPort1.SetVMin(i);
-            short vMin = serialPort1.GetVMin();
-            ASSERT_EQ(vMin, i);
-        }
-
-        serialPort1.Close();
-        ASSERT_FALSE(serialPort1.IsOpen());
-    }
-
-    void testSerialPortSetGetVTime()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        ASSERT_TRUE(serialPort1.IsOpen());
-
-        for (short i = 0; i < 5; i++)
-        {
-            serialPort1.SetVTime(i);
-            short vTime = serialPort1.GetVTime();
-            ASSERT_EQ(vTime, i);
-        }
-
-        serialPort1.Close();
-        ASSERT_FALSE(serialPort1.IsOpen());
-    }
-
-    void testSerialPortSetGetDTR()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-        serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        bool dtrLine1 = false;
-        bool dtrLine2 = false;
-
-        dtrLine1 = serialPort1.GetDTR();
-        dtrLine2 = serialPort2.GetDTR();
-
-        ASSERT_TRUE(dtrLine1);
-        ASSERT_TRUE(dtrLine2);
-
-        serialPort1.SetDTR(false);
-        serialPort2.SetDTR(false);
-
-        dtrLine1 = serialPort1.GetDTR();
-        dtrLine2 = serialPort2.GetDTR();
-
-        ASSERT_FALSE(dtrLine1);
-        ASSERT_FALSE(dtrLine2);
-
-        serialPort1.SetDTR(true);
-        serialPort2.SetDTR(true);
-
-        dtrLine1 = serialPort1.GetDTR();
-        dtrLine2 = serialPort2.GetDTR();
-
-        ASSERT_TRUE(dtrLine1);
-        ASSERT_TRUE(dtrLine2);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetGetRTS()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-        serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        bool rtsLine1 = false;
-        bool rtsLine2 = false;
-
-        rtsLine1 = serialPort1.GetRTS();
-        rtsLine2 = serialPort2.GetRTS();
-        
-        ASSERT_TRUE(rtsLine1);
-        ASSERT_TRUE(rtsLine2);
-
-        serialPort1.SetRTS(false);
-        serialPort2.SetRTS(false);
-        
-        rtsLine1 = serialPort1.GetRTS();
-        rtsLine2 = serialPort2.GetRTS();
-        
-        ASSERT_FALSE(rtsLine1);
-        ASSERT_FALSE(rtsLine2);
-
-        serialPort1.SetRTS(true);
-        serialPort2.SetRTS(true);
-
-        rtsLine1 = serialPort1.GetRTS();
-        rtsLine2 = serialPort2.GetRTS();
-
-        ASSERT_TRUE(rtsLine1);
-        ASSERT_TRUE(rtsLine2);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetRTSGetCTS()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-        serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        bool ctsLine1 = false;
-        bool ctsLine2 = false;
-
-        ctsLine1 = serialPort1.GetCTS();
-        ctsLine2 = serialPort2.GetCTS();
-
-        ASSERT_TRUE(ctsLine1);
-        ASSERT_TRUE(ctsLine2);
-
-        serialPort1.SetRTS(false);
-        serialPort2.SetRTS(false);
-
-        ctsLine1 = serialPort1.GetCTS();
-        ctsLine2 = serialPort2.GetCTS();
-
-        ASSERT_FALSE(ctsLine1);
-        ASSERT_FALSE(ctsLine2);
-
-        serialPort1.SetRTS(true);
-        serialPort2.SetRTS(true);
-
-        ctsLine1 = serialPort1.GetCTS();
-        ctsLine2 = serialPort2.GetCTS();
-
-        ASSERT_TRUE(ctsLine1);
-        ASSERT_TRUE(ctsLine2);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortSetDTRGetDSR()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-        serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        bool dsrStatus1 = false;
-        bool dsrStatus2 = false;
-
-        dsrStatus1 = serialPort1.GetDSR();
-        dsrStatus2 = serialPort1.GetDSR();
-
-        ASSERT_TRUE(dsrStatus1);
-        ASSERT_TRUE(dsrStatus2);
-
-        serialPort1.SetDTR(false);
-        serialPort2.SetDTR(false);
-
-        dsrStatus1 = serialPort1.GetDSR();
-        dsrStatus2 = serialPort2.GetDSR();
-
-        ASSERT_FALSE(dsrStatus1);
-        ASSERT_FALSE(dsrStatus2);
-
-        serialPort1.SetDTR(true);
-        serialPort2.SetDTR(true);
-
-        dsrStatus1 = serialPort1.GetDSR();
-        dsrStatus2 = serialPort2.GetDSR();
-
-        ASSERT_TRUE(dsrStatus1);
-        ASSERT_TRUE(dsrStatus2);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortGetFileDescriptor()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        int fileDescriptor1 = serialPort1.GetFileDescriptor();
-        int fileDescriptor2 = serialPort2.GetFileDescriptor();
-
-        ASSERT_GT(fileDescriptor1, 0);
-        ASSERT_GT(fileDescriptor2, 0);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortGetNumberOfBytesAvailable()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        char writeByte1 = 'a';
-        char writeByte2 = 'A';
-
-        char readByte1  = 'b';
-        char readByte2  = 'B';
-
-        int bytesAvailable1 = 0;
-        int bytesAvailable2 = 0;
-
-        bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
-        bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
-
-        serialPort1.WriteByte(writeByte1);
-        serialPort2.WriteByte(writeByte2);
-
-        serialPort1.DrainWriteBuffer();
-        serialPort2.DrainWriteBuffer();
-
-        usleep(readBufferDelay);
-
-        bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
-        bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
-
-        ASSERT_EQ(bytesAvailable1, 1);
-        ASSERT_EQ(bytesAvailable2, 1);
-
-        serialPort1.ReadByte(readByte2, 1);
-        serialPort2.ReadByte(readByte1, 1);
-
-        bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
-        bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
-
-        ASSERT_EQ(bytesAvailable1, 0);
-        ASSERT_EQ(bytesAvailable2, 0);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortGetAvailableSerialPorts()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        std::vector<std::string> serialPorts1;
-        std::vector<std::string> serialPorts2;
- 
-        serialPorts1.clear();
-        serialPorts2.clear();
- 
-        serialPorts1 = serialPort1.GetAvailableSerialPorts();
-        serialPorts2 = serialPort2.GetAvailableSerialPorts();
- 
-        int portCount1 = (int)serialPorts1.size();
-        int portCount2 = (int)serialPorts2.size();
-
-        ASSERT_GE(portCount1, 2);
-        ASSERT_GE(portCount2, 2);
-        ASSERT_EQ(portCount1, portCount2);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortReadDataBufferWriteDataBuffer()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        const size_t data_count = 75;
-
-        bool timeOutTestPass = false;
-
-        DataBuffer writeVector1;
-        DataBuffer writeVector2;
-
-        DataBuffer readVector1;
-        DataBuffer readVector2;
-
-        // Test using ASCII characters.
-        for (unsigned char i = 0; i < data_count; i++)
-        {
-            writeVector1.push_back((char)(48 + i));
-            writeVector2.push_back((char)(122 - i));
-        }
-
-        serialPort1.Write(writeVector1);
-        serialPort2.Write(writeVector2);
-
-        serialPort1.DrainWriteBuffer();
-        serialPort2.DrainWriteBuffer();
-
-        serialPort1.Read(readVector2, data_count, timeOutMilliseconds);
-        serialPort2.Read(readVector1, data_count, timeOutMilliseconds);
-
-        ASSERT_EQ(readVector1, writeVector1);
-        ASSERT_EQ(readVector2, writeVector2);
-
-        readVector1.clear();
-        readVector2.clear();
-
-        try
-        {
-            serialPort1.Write(writeVector1);
-
-            serialPort1.DrainWriteBuffer();
-
-            serialPort2.Read(readVector1, 0, 75);
-        }
-        catch(...)
-        {
-            timeOutTestPass = true;
-        }
-
-        ASSERT_TRUE(timeOutTestPass);
-        ASSERT_EQ(readVector1, writeVector1);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortReadStringWriteString()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        bool timeOutTestPass = false;
-
-        serialPort1.Write(writeString1);
-        serialPort2.Write(writeString2);
-
-        serialPort1.DrainWriteBuffer();
-        serialPort2.DrainWriteBuffer();
-
-        serialPort1.Read(readString2, writeString2.size(), timeOutMilliseconds);
-        serialPort2.Read(readString1, writeString1.size(), timeOutMilliseconds);
-
-        ASSERT_EQ(readString1, writeString1);
-        ASSERT_EQ(readString2, writeString2);
-
-        timeOutTestPass = false;
-
-        readString1.clear();
-        readString2.clear();
-
-        try
-        {
-            serialPort1.Write(writeString1);
-
-            serialPort1.DrainWriteBuffer();
-
-            serialPort2.Read(readString1, 0, 75);
-        }
-        catch(...)
-        {
-            timeOutTestPass = true;
-        }
-
-        ASSERT_TRUE(timeOutTestPass);
-        ASSERT_EQ(readString1, writeString1);
-        
-        serialPort1.Close();
-        serialPort2.Close();
-        
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortReadByteWriteByte()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        bool timeOutTestPass = false;
-
-        char writeByte1 = 'a';
-        unsigned char writeByte2 = 'A';
-
-        char readByte1  = 'b';
-        unsigned char readByte2  = 'B';
-
-        serialPort1.WriteByte(writeByte1);
-        serialPort2.WriteByte(writeByte2);
-
-        serialPort1.DrainWriteBuffer();
-        serialPort2.DrainWriteBuffer();
-
-        serialPort1.ReadByte(readByte2, timeOutMilliseconds);
-        serialPort2.ReadByte(readByte1, timeOutMilliseconds);
-
-        ASSERT_EQ(readByte1, writeByte1);
-        ASSERT_EQ(readByte2, writeByte2);
-
-        try
-        {
-            serialPort1.ReadByte(readByte1, 1);
-            serialPort2.ReadByte(readByte2, 1);
-        }
-        catch(ReadTimeout)
-        {
-            timeOutTestPass = true;
-        }
-
-        ASSERT_TRUE(timeOutTestPass);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialPortReadLineWriteString()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-
-        ASSERT_TRUE(serialPort1.IsOpen());
-        ASSERT_TRUE(serialPort2.IsOpen());
-
-        bool timeOutTestPass = false;
-
-        serialPort1.Write(writeString1 + '\n');
-        serialPort2.Write(writeString2 + '\n');
-
-        serialPort1.DrainWriteBuffer();
-        serialPort2.DrainWriteBuffer();
-
-        serialPort1.ReadLine(readString2, '\n', timeOutMilliseconds);
-        serialPort2.ReadLine(readString1, '\n', timeOutMilliseconds);
-
-        ASSERT_EQ(readString1, writeString1 + '\n');
-        ASSERT_EQ(readString2, writeString2 + '\n');
-
-        try
-        {
-            serialPort1.ReadLine(readString2, '\n', 1);
-            serialPort2.ReadLine(readString1, '\n', 1);
-        }
-        catch(ReadTimeout)
-        {
-            timeOutTestPass = true;
-        }
-
-        ASSERT_TRUE(timeOutTestPass);
-
-        serialPort1.Close();
-        serialPort2.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialPort2.IsOpen());
-    }
-
-    void testSerialStreamToSerialPortReadWrite()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        ASSERT_TRUE(serialPort1.IsOpen());
-
-        serialStream1.Open(TEST_SERIAL_PORT_2);
-        ASSERT_TRUE(serialStream1.IsOpen());
-
-        const auto baud_rate = BaudRate::BAUD_115200 ;
-        serialPort1.SetBaudRate(baud_rate);
         serialStream1.SetBaudRate(baud_rate);
+        serialStream2.SetBaudRate(baud_rate);
 
-        BaudRate baudRate1 = serialPort1.GetBaudRate();
-        BaudRate baudRate2 = serialStream1.GetBaudRate();
+        const auto baudRate1 = serialStream1.GetBaudRate();
+        const auto baudRate2 = serialStream2.GetBaudRate();
 
         ASSERT_EQ(baudRate1, baud_rate);
         ASSERT_EQ(baudRate2, baud_rate);
-
-        serialStream1 << writeString1 << std::endl;
-        serialPort1.ReadLine(readString1, '\n', timeOutMilliseconds);
-
-        ASSERT_EQ(readString1, writeString1 + '\n');
-        ASSERT_EQ(readString1.size(), writeString1.size() + 1);
-
-        serialPort1.Write(writeString2 + '\n');
-        serialPort1.DrainWriteBuffer();
-        getline(serialStream1, readString2);
-
-        ASSERT_EQ(readString2, writeString2);
-
-        serialPort1.Close();
-        serialStream1.Close();
-
-        ASSERT_FALSE(serialPort1.IsOpen());
-        ASSERT_FALSE(serialStream1.IsOpen());
     }
 
-    void serialStream1ThreadLoop()
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetCharacterSize()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    for (const auto char_size: characterSizes)
     {
-        serialStream1.Open(TEST_SERIAL_PORT_1);
-        serialStream1.SetBaudRate(BaudRate::BAUD_115200);
-        serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        size_t threadLoopStartTimeMilliseconds = getTimeInMilliSeconds();
-        size_t timeElapsedMilliSeconds = 0;
-
-        while (timeElapsedMilliSeconds < timeOutMilliseconds)
+        // @NOTE - Smaller Character Size values do not work in Linux.
+        if (char_size < CharacterSize::CHAR_SIZE_7)
         {
-            serialStream1 << writeString1 << std::endl;
-            serialStream1.DrainWriteBuffer();
-
-            if (serialStream1.IsDataAvailable())
-            {
-                alarm(5);   // Set a system alarm in case getline() blocks longer than 5 seconds.
-                getline(serialStream1, readString2);
-                alarm(0);   // Deactivate the alarm.
-                
-                if(readString2 != writeString2)
-                {
-                    mutex.lock();
-                    failureRate++;
-                    mutex.unlock();
-                }
-            }
-
-            timeElapsedMilliSeconds = getTimeInMilliSeconds() - threadLoopStartTimeMilliseconds;
-
-            mutex.lock();
-            loopCount++;
-            mutex.unlock();
+            continue;
         }
-
-        serialStream1.Close();
-        return;
-    }
-
-    void serialStream2ThreadLoop()
-    {
-        serialStream2.Open(TEST_SERIAL_PORT_2);
-        serialStream2.SetBaudRate(BaudRate::BAUD_115200);
-        serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        size_t threadLoopStartTimeMilliseconds = getTimeInMilliSeconds();
-        size_t timeElapsedMilliSeconds = 0;
-
-        while (timeElapsedMilliSeconds < timeOutMilliseconds)
-        {
-            serialStream2 << writeString2 << std::endl;
-            serialStream2.DrainWriteBuffer();
-
-            if (serialStream2.IsDataAvailable())
-            {
-                alarm(5);   // Set a system alarm in case getline() blocks longer than 5 seconds.
-                getline(serialStream2, readString1);
-                alarm(0);   // Deactivate the alarm.
-
-                if(readString1 != writeString1)
-                {
-                    mutex.lock();
-                    failureRate++;
-                    mutex.unlock();
-                }
-            }
-            
-            timeElapsedMilliSeconds = getTimeInMilliSeconds() - threadLoopStartTimeMilliseconds;
-            
-            mutex.lock();
-            loopCount++;
-            mutex.unlock();
-        }
-
-        serialStream2.Close();
-        return;
-    }
-
-    void serialPort1ThreadLoop()
-    {
-        serialPort1.Open(TEST_SERIAL_PORT_1);
-        serialPort1.SetBaudRate(BaudRate::BAUD_115200);
-        serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        tcflush(serialPort1.GetFileDescriptor(), TCIOFLUSH);
-
-        size_t threadLoopStartTimeMilliseconds = getTimeInMilliSeconds();
-        size_t timeElapsedMilliSeconds = 0;
-
-        while (timeElapsedMilliSeconds < timeOutMilliseconds)
-        {
-           
-            serialPort1.Write(writeString1 + '\n');
-            serialPort1.DrainWriteBuffer();
-
-            if (serialPort1.IsDataAvailable())
-            {
-                try
-                {
-                    serialPort1.ReadLine(readString2, '\n', timeOutMilliseconds);
-
-                    if(readString2 != writeString2 + '\n')
-                    {
-                        mutex.lock();
-                        failureRate++;
-                        mutex.unlock();
-                    }
-                }
-                catch(...)
-                {
-                }
-            }
-
-            timeElapsedMilliSeconds = getTimeInMilliSeconds() - threadLoopStartTimeMilliseconds;
-
-            mutex.lock();
-            loopCount++;
-            mutex.unlock();
-        }
-
-        serialPort1.Close();
-        return;
-    }
-
-    void serialPort2ThreadLoop()
-    {
-        serialPort2.Open(TEST_SERIAL_PORT_2);
-        serialPort2.SetBaudRate(BaudRate::BAUD_115200);
-        serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
-
-        tcflush(serialPort1.GetFileDescriptor(), TCIOFLUSH);
-
-        size_t threadLoopStartTimeMilliseconds = getTimeInMilliSeconds();
-        size_t timeElapsedMilliSeconds = 0;
-
-        while (timeElapsedMilliSeconds < timeOutMilliseconds)
-        {
-            serialPort2.Write(writeString2 + '\n');
-            serialPort2.DrainWriteBuffer();
-
-            if (serialPort2.IsDataAvailable())
-            {
-                try
-                {
-                    serialPort2.ReadLine(readString1, '\n', timeOutMilliseconds);
-
-                    if(readString1 != writeString1 + '\n')
-                    {
-                        mutex.lock();
-                        failureRate++;
-                        mutex.unlock();
-                    }
-                }
-                catch(...)
-                {
-                }
-            }
-
-            timeElapsedMilliSeconds = getTimeInMilliSeconds() - threadLoopStartTimeMilliseconds;
-
-            mutex.lock();
-            loopCount++;
-            mutex.unlock();
-        }
-
-        serialPort2.Close();
-        return;
-    }
-
-    void testMultiThreadSerialStreamReadWrite()
-    {
-        failureRate = 0;
-        loopCount = 0;
-
-        std::thread serialStream1Thread(&LibSerialTest::serialStream1ThreadLoop, this);
-        std::thread serialStream2Thread(&LibSerialTest::serialStream2ThreadLoop, this);
-
-        serialStream1Thread.join();
-        serialStream2Thread.join();
-    }
-
-    void testMultiThreadSerialPortReadWrite()
-    {
-        failureRate = 0;
-        loopCount = 0;
         
-        std::thread serialPort1Thread(&LibSerialTest::serialPort1ThreadLoop, this);
-        std::thread serialPort2Thread(&LibSerialTest::serialPort2ThreadLoop, this);
+        serialStream1.SetCharacterSize(char_size);
+        serialStream2.SetCharacterSize(char_size);
 
-        serialPort1Thread.join();
-        serialPort2Thread.join();
+        const auto characterSize1 = serialStream1.GetCharacterSize();
+        const auto characterSize2 = serialStream2.GetCharacterSize();
+
+        ASSERT_EQ(characterSize1, char_size);
+        ASSERT_EQ(characterSize2, char_size);
     }
-};
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetFlowControl()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    for (const auto flow_control: flowControlTypes)
+    {
+        serialStream1.SetFlowControl(flow_control);
+        serialStream1.SetFlowControl(flow_control);
+
+        const auto flowControl1 = serialStream1.GetFlowControl();
+        const auto flowControl2 = serialStream1.GetFlowControl();
+
+        ASSERT_EQ(flowControl1, flow_control);
+        ASSERT_EQ(flowControl2, flow_control);
+    }
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetParity()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    for (const auto parity: parityTypes)
+    {
+        serialStream1.SetParity(parity);
+        serialStream2.SetParity(parity);
+
+        const auto parity1 = serialStream1.GetParity();
+        const auto parity2 = serialStream2.GetParity();
+
+        ASSERT_EQ(parity1, parity);
+        ASSERT_EQ(parity2, parity);
+    }
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetStopBits()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    for (const auto stop_bits: stopBits)
+    {
+        serialStream1.SetStopBits(stop_bits);
+        serialStream2.SetStopBits(stop_bits);
+
+        const auto numberOfStopBits1 = serialStream1.GetStopBits();
+        const auto numberOfStopBits2 = serialStream2.GetStopBits();
+
+        ASSERT_EQ(numberOfStopBits1, stop_bits);
+        ASSERT_EQ(numberOfStopBits2, stop_bits);
+    }
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetVMin()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    short vMin1 = 0;
+    short vMin2 = 0;
+
+    for (short i = 0; i < 5; i++)
+    {
+        serialStream1.SetVMin(i);
+        serialStream2.SetVMin(i);
+
+        vMin1 = serialStream1.GetVMin();
+        vMin2 = serialStream2.GetVMin();
+
+        ASSERT_EQ(vMin1, i);
+        ASSERT_EQ(vMin2, i);
+    }
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetVTime()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    short vTime1 = 0;
+    short vTime2 = 0;
+
+    for (short i = 0; i < 5; i++)
+    {
+        serialStream1.SetVTime(i);
+        serialStream2.SetVTime(i);
+
+        vTime1 = serialStream1.GetVTime();
+        vTime2 = serialStream2.GetVTime();
+
+        ASSERT_EQ(vTime1, i);
+        ASSERT_EQ(vTime2, i);
+    }
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetDTR()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+    serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    bool dtrLine1 = false;
+    bool dtrLine2 = false;
+
+    dtrLine1 = serialStream1.GetDTR();
+    dtrLine2 = serialStream2.GetDTR();
+
+    ASSERT_TRUE(dtrLine1);
+    ASSERT_TRUE(dtrLine2);
+
+    serialStream1.SetDTR(true);
+    serialStream2.SetDTR(true);
+
+    dtrLine1 = serialStream1.GetDTR();
+    dtrLine2 = serialStream2.GetDTR();
+
+    ASSERT_TRUE(dtrLine1);
+    ASSERT_TRUE(dtrLine2);
+
+    serialStream1.SetDTR(false);
+    serialStream2.SetDTR(false);
+
+    dtrLine1 = serialStream1.GetDTR();
+    dtrLine2 = serialStream2.GetDTR();
+
+    ASSERT_FALSE(dtrLine1);
+    ASSERT_FALSE(dtrLine2);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetGetRTS()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+    serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    bool rtsLine1 = false;
+    bool rtsLine2 = false;
+
+    rtsLine1 = serialStream1.GetRTS();
+    rtsLine2 = serialStream2.GetRTS();
+    
+    ASSERT_TRUE(rtsLine1);
+    ASSERT_TRUE(rtsLine2);
+
+    serialStream1.SetRTS(false);
+    serialStream2.SetRTS(false);
+    
+    rtsLine1 = serialStream1.GetRTS();
+    rtsLine2 = serialStream2.GetRTS();
+    
+    ASSERT_FALSE(rtsLine1);
+    ASSERT_FALSE(rtsLine2);
+
+    serialStream1.SetRTS(true);
+    serialStream2.SetRTS(true);
+
+    rtsLine1 = serialStream1.GetRTS();
+    rtsLine2 = serialStream2.GetRTS();
+
+    ASSERT_TRUE(rtsLine1);
+    ASSERT_TRUE(rtsLine2);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetRTSGetCTS()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+    serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    bool ctsLine1 = false;
+    bool ctsLine2 = false;
+
+    ctsLine1 = serialStream1.GetCTS();
+    ctsLine2 = serialStream2.GetCTS();
+
+    ASSERT_TRUE(ctsLine1);
+    ASSERT_TRUE(ctsLine2);
+
+    serialStream1.SetRTS(false);
+    serialStream2.SetRTS(false);
+
+    ctsLine1 = serialStream1.GetCTS();
+    ctsLine2 = serialStream2.GetCTS();
+
+    ASSERT_FALSE(ctsLine1);
+    ASSERT_FALSE(ctsLine2);
+
+    serialStream1.SetRTS(true);
+    serialStream2.SetRTS(true);
+
+    ctsLine1 = serialStream1.GetCTS();
+    ctsLine2 = serialStream2.GetCTS();
+
+    ASSERT_TRUE(ctsLine1);
+    ASSERT_TRUE(ctsLine2);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamSetDTRGetDSR()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+    serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    bool dsrStatus1 = false;
+    bool dsrStatus2 = false;
+
+    dsrStatus1 = serialStream1.GetDSR();
+    dsrStatus2 = serialStream2.GetDSR();
+
+    ASSERT_TRUE(dsrStatus1);
+    ASSERT_TRUE(dsrStatus2);
+
+    serialStream1.SetDTR(false);
+    serialStream2.SetDTR(false);
+
+    dsrStatus1 = serialStream1.GetDSR();
+    dsrStatus2 = serialStream2.GetDSR();
+
+    ASSERT_FALSE(dsrStatus1);
+    ASSERT_FALSE(dsrStatus2);
+
+    serialStream1.SetDTR(true);
+    serialStream2.SetDTR(true);
+
+    dsrStatus1 = serialStream1.GetDSR();
+    dsrStatus2 = serialStream2.GetDSR();
+
+    ASSERT_TRUE(dsrStatus1);
+    ASSERT_TRUE(dsrStatus2);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamGetFileDescriptor()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    int fileDescriptor1 = serialStream1.GetFileDescriptor();
+    int fileDescriptor2 = serialStream2.GetFileDescriptor();
+
+    ASSERT_GT(fileDescriptor1, 0);
+    ASSERT_GT(fileDescriptor2, 0);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamGetNumberOfBytesAvailable()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    char writeByte1 = 'a';
+    char writeByte2 = 'A';
+
+    char readByte1  = 'b';
+    char readByte2  = 'B';
+
+    int bytesAvailable1 = 0;
+    int bytesAvailable2 = 0;
+
+    serialStream1.write(&writeByte1, 1);
+    serialStream2.write(&writeByte2, 1);
+
+    serialStream1.DrainWriteBuffer();
+    serialStream2.DrainWriteBuffer();
+
+    usleep(readBufferDelay);
+
+    bytesAvailable1 = serialStream1.GetNumberOfBytesAvailable();
+    bytesAvailable2 = serialStream2.GetNumberOfBytesAvailable();
+
+    ASSERT_EQ(bytesAvailable1, 1);
+    ASSERT_EQ(bytesAvailable2, 1);
+
+    serialStream1.read(&readByte2, 1);
+    serialStream2.read(&readByte1, 1);
+
+    bytesAvailable1 = serialStream1.GetNumberOfBytesAvailable();
+    bytesAvailable2 = serialStream2.GetNumberOfBytesAvailable();
+
+    ASSERT_EQ(bytesAvailable1, 0);
+    ASSERT_EQ(bytesAvailable2, 0);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamGetAvailableSerialPorts()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    std::vector<std::string> serialPorts1;
+    std::vector<std::string> serialPorts2;
+
+    serialPorts1.clear();
+    serialPorts2.clear();
+
+    serialPorts1 = serialStream1.GetAvailableSerialPorts();
+    serialPorts2 = serialStream2.GetAvailableSerialPorts();
+
+    int portCount1 = (int)serialPorts1.size();
+    int portCount2 = (int)serialPorts2.size();
+
+    ASSERT_GE(portCount1, 2);
+    ASSERT_GE(portCount2, 2);
+    ASSERT_EQ(portCount1, portCount2);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamReadByteWriteByte()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    char writeByte1 = 'a';
+    char writeByte2 = 'A';
+
+    char readByte1  = 'b';
+    char readByte2  = 'B';
+
+    serialStream1.write(&writeByte1, 1);
+    serialStream2.write(&writeByte2, 1);
+
+    serialStream1.read(&readByte2, 1);
+    serialStream2.read(&readByte1, 1);
+
+    ASSERT_EQ(readByte1, writeByte1);
+    ASSERT_EQ(readByte2, writeByte2);
+
+    serialStream1 << writeByte1;
+    serialStream2 << writeByte2;
+
+    serialStream1.read(&readByte2, 1);
+    serialStream2.read(&readByte1, 1);
+
+    ASSERT_EQ(readByte1, writeByte1);
+    ASSERT_EQ(readByte2, writeByte2);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamGetLineWriteString()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    serialStream1 << writeString1 << std::endl;
+    serialStream2 << writeString2 << std::endl;
+
+    getline(serialStream1, readString2);
+    getline(serialStream2, readString1);
+
+    ASSERT_EQ(readString1, writeString1);
+    ASSERT_EQ(readString2, writeString2);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamGetWriteByte()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialStream1.IsOpen());
+    ASSERT_TRUE(serialStream2.IsOpen());
+
+    char writeByte1 = 'a';
+    char writeByte2 = 'A';
+
+    char readByte1  = 'b';
+    char readByte2  = 'B';
+
+    serialStream1.write(&writeByte1, 1);
+    serialStream2.write(&writeByte2, 1);
+
+    serialStream1.get(readByte2);
+    serialStream2.get(readByte1);
+
+    ASSERT_EQ(readByte1, writeByte1);
+    ASSERT_EQ(readByte2, writeByte2);
+
+    serialStream1 << writeByte1;
+    serialStream2 << writeByte2;
+
+    serialStream1.get(readByte2);
+    serialStream2.get(readByte1);
+
+    ASSERT_EQ(readByte1, writeByte1);
+    ASSERT_EQ(readByte2, writeByte2);
+
+    serialStream1.Close();
+    serialStream2.Close();
+
+    ASSERT_FALSE(serialStream1.IsOpen());
+    ASSERT_FALSE(serialStream2.IsOpen());
+}
+
+
+//----------------------- Serial Port Unit Tests ------------------------//
+
+void
+LibSerialTest::testSerialPortConstructors()
+{
+    SerialPort serialPort3(TEST_SERIAL_PORT_1);
+    SerialPort serialPort4(TEST_SERIAL_PORT_2,
+                           BaudRate::BAUD_9600,
+                           CharacterSize::CHAR_SIZE_7,
+                           FlowControl::FLOW_CONTROL_HARDWARE,
+                           Parity::PARITY_EVEN,
+                           StopBits::STOP_BITS_2);
+
+    ASSERT_TRUE(serialPort3.IsOpen());
+    ASSERT_TRUE(serialPort4.IsOpen());
+    
+    ASSERT_EQ(serialPort4.GetBaudRate(),      BaudRate::BAUD_9600);
+    ASSERT_EQ(serialPort4.GetCharacterSize(), CharacterSize::CHAR_SIZE_7);
+    ASSERT_EQ(serialPort4.GetFlowControl(),   FlowControl::FLOW_CONTROL_HARDWARE);
+    ASSERT_EQ(serialPort4.GetParity(),        Parity::PARITY_EVEN);
+    ASSERT_EQ(serialPort4.GetStopBits(),      StopBits::STOP_BITS_2);
+    
+    serialPort3.Close();
+    serialPort4.Close();
+
+    ASSERT_FALSE(serialPort3.IsOpen());
+    ASSERT_FALSE(serialPort4.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortOpenClose()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    SerialPort serialPort3;
+    SerialPort serialPort4;
+
+    ASSERT_FALSE(serialPort3.IsOpen());
+    ASSERT_FALSE(serialPort4.IsOpen());
+
+    bool exclusiveUseTestPass = false;
+
+    try
+    {
+        serialPort3.Open(TEST_SERIAL_PORT_1);
+        serialPort4.Open(TEST_SERIAL_PORT_2);
+    }
+    catch (...)
+    {
+        exclusiveUseTestPass = true;
+    }
+
+    ASSERT_TRUE(exclusiveUseTestPass);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortDrainWriteBuffer()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    serialPort1.FlushIOBuffers();
+    serialPort2.FlushIOBuffers();
+
+    serialPort1.Write(writeString1);
+    serialPort2.Write(writeString2);
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    serialPort1.DrainWriteBuffer();
+    serialPort2.DrainWriteBuffer();
+
+    // Allow time for the read buffers to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialPort1.IsDataAvailable());
+    ASSERT_TRUE(serialPort2.IsDataAvailable());
+
+    serialPort1.FlushIOBuffers();
+    serialPort2.FlushIOBuffers();
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortFlushInputBuffer()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    serialPort1.FlushInputBuffer();
+    serialPort2.FlushInputBuffer();
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    char writeByte = 'A';
+
+    serialPort1.WriteByte(writeByte);
+    serialPort2.WriteByte(writeByte);
+
+    serialPort1.DrainWriteBuffer();
+    serialPort2.DrainWriteBuffer();
+
+    // Allow time for the read buffers to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialPort1.IsDataAvailable());
+    ASSERT_TRUE(serialPort2.IsDataAvailable());
+
+    serialPort1.FlushInputBuffer();
+    serialPort2.FlushInputBuffer();
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortFlushOutputBuffer()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    serialPort1.FlushInputBuffer();
+    serialPort2.FlushInputBuffer();
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    char writeByte = 'A';
+    
+    serialPort1.WriteByte(writeByte);
+    serialPort1.FlushOutputBuffer();
+
+    serialPort2.WriteByte(writeByte);
+    serialPort2.FlushOutputBuffer();
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    serialPort1.Close();
+    serialPort2.Close();
+    
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortFlushIOBuffers()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    char writeByte = 'a';
+
+    serialPort1.WriteByte(writeByte);
+    serialPort1.FlushIOBuffers();
+
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    serialPort2.WriteByte(writeByte);
+    serialPort2.FlushIOBuffers();
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+
+    serialPort1.WriteByte(writeByte);
+    serialPort2.WriteByte(writeByte);
+
+    serialPort1.DrainWriteBuffer();
+    serialPort2.DrainWriteBuffer();
+    
+    // Allow time for the read buffers to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialPort1.IsDataAvailable());
+    ASSERT_TRUE(serialPort2.IsDataAvailable());
+
+    serialPort1.FlushIOBuffers();
+    serialPort2.FlushIOBuffers();
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortIsDataAvailableTest()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    char writeByte = 'a';
+    char readByte = 'b';
+
+    serialPort1.WriteByte(writeByte);
+    serialPort1.DrainWriteBuffer();
+
+    // Allow time for the read buffer to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialPort2.IsDataAvailable());
+
+    serialPort2.ReadByte(readByte, 1);
+    ASSERT_EQ(readByte, writeByte);
+
+    serialPort2.WriteByte(writeByte);
+    serialPort2.DrainWriteBuffer();
+
+    // Allow time for the read buffer to show that data is available.
+    usleep(readBufferDelay);
+
+    ASSERT_TRUE(serialPort1.IsDataAvailable());
+
+    serialPort1.ReadByte(readByte, 1);
+    ASSERT_EQ(readByte, writeByte);
+
+    ASSERT_FALSE(serialPort1.IsDataAvailable());
+    ASSERT_FALSE(serialPort2.IsDataAvailable());
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortIsOpenTest()
+{
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetBaudRate()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    for(const auto baud_rate: baudRates)
+    {
+        serialPort1.SetBaudRate(baud_rate);
+        serialPort2.SetBaudRate(baud_rate);
+
+        const auto baudRate1 = serialPort1.GetBaudRate();
+        const auto baudRate2 = serialPort1.GetBaudRate();
+
+        ASSERT_EQ(baudRate1, baud_rate);
+        ASSERT_EQ(baudRate2, baud_rate);
+    }
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetCharacterSize()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    for(const auto char_size: characterSizes)
+    {
+        // @NOTE - Smaller CharSize values appear to be invalid on x86 Linux.
+        if (char_size < CharacterSize::CHAR_SIZE_7)
+        {
+            continue;
+        }
+
+        serialPort1.SetCharacterSize(char_size);
+        serialPort2.SetCharacterSize(char_size);
+
+        const auto characterSize1 = serialPort1.GetCharacterSize();
+        const auto characterSize2 = serialPort2.GetCharacterSize();
+
+        ASSERT_EQ(characterSize1, char_size);
+        ASSERT_EQ(characterSize2, char_size);
+    }
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetFlowControl()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    for (const auto flow_control: flowControlTypes)
+    {
+        // @NOTE - FLOW_CONTROL_SOFT flow control appears to be invalid on x86 Linux.
+        if (flow_control == FlowControl::FLOW_CONTROL_SOFTWARE)
+        {
+            continue;
+        }
+
+        serialPort1.SetFlowControl(flow_control);
+        serialPort2.SetFlowControl(flow_control);
+
+        const auto flowControl1 = serialPort1.GetFlowControl();
+        const auto flowControl2 = serialPort2.GetFlowControl();
+
+        ASSERT_EQ(flowControl1, flow_control);
+        ASSERT_EQ(flowControl2, flow_control);
+    }
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetParity()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    for (const auto parity: parityTypes)
+    {
+        serialPort1.SetParity(parity);
+        serialPort2.SetParity(parity);
+
+        const auto parity1 = serialPort1.GetParity();
+        const auto parity2 = serialPort2.GetParity();
+
+        ASSERT_EQ(parity1, parity);
+        ASSERT_EQ(parity2, parity);
+    }
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetStopBits()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    for (const auto stop_bits: stopBits)
+    {
+        serialPort1.SetStopBits(stop_bits);
+        serialPort2.SetStopBits(stop_bits);
+
+        const auto stopBits1 = serialPort1.GetStopBits();
+        const auto stopBits2 = serialPort2.GetStopBits();
+
+        ASSERT_EQ(stopBits1, stop_bits);
+        ASSERT_EQ(stopBits2, stop_bits);
+    }
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetVMin()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    ASSERT_TRUE(serialPort1.IsOpen());
+
+    for (short i = 0; i < 5; i++)
+    {
+        serialPort1.SetVMin(i);
+        short vMin = serialPort1.GetVMin();
+        ASSERT_EQ(vMin, i);
+    }
+
+    serialPort1.Close();
+    ASSERT_FALSE(serialPort1.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetVTime()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    ASSERT_TRUE(serialPort1.IsOpen());
+
+    for (short i = 0; i < 5; i++)
+    {
+        serialPort1.SetVTime(i);
+        short vTime = serialPort1.GetVTime();
+        ASSERT_EQ(vTime, i);
+    }
+
+    serialPort1.Close();
+    ASSERT_FALSE(serialPort1.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetDTR()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+    serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    bool dtrLine1 = false;
+    bool dtrLine2 = false;
+
+    dtrLine1 = serialPort1.GetDTR();
+    dtrLine2 = serialPort2.GetDTR();
+
+    ASSERT_TRUE(dtrLine1);
+    ASSERT_TRUE(dtrLine2);
+
+    serialPort1.SetDTR(false);
+    serialPort2.SetDTR(false);
+
+    dtrLine1 = serialPort1.GetDTR();
+    dtrLine2 = serialPort2.GetDTR();
+
+    ASSERT_FALSE(dtrLine1);
+    ASSERT_FALSE(dtrLine2);
+
+    serialPort1.SetDTR(true);
+    serialPort2.SetDTR(true);
+
+    dtrLine1 = serialPort1.GetDTR();
+    dtrLine2 = serialPort2.GetDTR();
+
+    ASSERT_TRUE(dtrLine1);
+    ASSERT_TRUE(dtrLine2);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetGetRTS()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+    serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    bool rtsLine1 = false;
+    bool rtsLine2 = false;
+
+    rtsLine1 = serialPort1.GetRTS();
+    rtsLine2 = serialPort2.GetRTS();
+    
+    ASSERT_TRUE(rtsLine1);
+    ASSERT_TRUE(rtsLine2);
+
+    serialPort1.SetRTS(false);
+    serialPort2.SetRTS(false);
+    
+    rtsLine1 = serialPort1.GetRTS();
+    rtsLine2 = serialPort2.GetRTS();
+    
+    ASSERT_FALSE(rtsLine1);
+    ASSERT_FALSE(rtsLine2);
+
+    serialPort1.SetRTS(true);
+    serialPort2.SetRTS(true);
+
+    rtsLine1 = serialPort1.GetRTS();
+    rtsLine2 = serialPort2.GetRTS();
+
+    ASSERT_TRUE(rtsLine1);
+    ASSERT_TRUE(rtsLine2);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetRTSGetCTS()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+    serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    bool ctsLine1 = false;
+    bool ctsLine2 = false;
+
+    ctsLine1 = serialPort1.GetCTS();
+    ctsLine2 = serialPort2.GetCTS();
+
+    ASSERT_TRUE(ctsLine1);
+    ASSERT_TRUE(ctsLine2);
+
+    serialPort1.SetRTS(false);
+    serialPort2.SetRTS(false);
+
+    ctsLine1 = serialPort1.GetCTS();
+    ctsLine2 = serialPort2.GetCTS();
+
+    ASSERT_FALSE(ctsLine1);
+    ASSERT_FALSE(ctsLine2);
+
+    serialPort1.SetRTS(true);
+    serialPort2.SetRTS(true);
+
+    ctsLine1 = serialPort1.GetCTS();
+    ctsLine2 = serialPort2.GetCTS();
+
+    ASSERT_TRUE(ctsLine1);
+    ASSERT_TRUE(ctsLine2);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortSetDTRGetDSR()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+    serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    bool dsrStatus1 = false;
+    bool dsrStatus2 = false;
+
+    dsrStatus1 = serialPort1.GetDSR();
+    dsrStatus2 = serialPort1.GetDSR();
+
+    ASSERT_TRUE(dsrStatus1);
+    ASSERT_TRUE(dsrStatus2);
+
+    serialPort1.SetDTR(false);
+    serialPort2.SetDTR(false);
+
+    dsrStatus1 = serialPort1.GetDSR();
+    dsrStatus2 = serialPort2.GetDSR();
+
+    ASSERT_FALSE(dsrStatus1);
+    ASSERT_FALSE(dsrStatus2);
+
+    serialPort1.SetDTR(true);
+    serialPort2.SetDTR(true);
+
+    dsrStatus1 = serialPort1.GetDSR();
+    dsrStatus2 = serialPort2.GetDSR();
+
+    ASSERT_TRUE(dsrStatus1);
+    ASSERT_TRUE(dsrStatus2);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortGetFileDescriptor()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    int fileDescriptor1 = serialPort1.GetFileDescriptor();
+    int fileDescriptor2 = serialPort2.GetFileDescriptor();
+
+    ASSERT_GT(fileDescriptor1, 0);
+    ASSERT_GT(fileDescriptor2, 0);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortGetNumberOfBytesAvailable()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    char writeByte1 = 'a';
+    char writeByte2 = 'A';
+
+    char readByte1  = 'b';
+    char readByte2  = 'B';
+
+    int bytesAvailable1 = 0;
+    int bytesAvailable2 = 0;
+
+    bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
+    bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
+
+    serialPort1.WriteByte(writeByte1);
+    serialPort2.WriteByte(writeByte2);
+
+    serialPort1.DrainWriteBuffer();
+    serialPort2.DrainWriteBuffer();
+
+    usleep(readBufferDelay);
+
+    bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
+    bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
+
+    ASSERT_EQ(bytesAvailable1, 1);
+    ASSERT_EQ(bytesAvailable2, 1);
+
+    serialPort1.ReadByte(readByte2, 1);
+    serialPort2.ReadByte(readByte1, 1);
+
+    bytesAvailable1 = serialPort1.GetNumberOfBytesAvailable();
+    bytesAvailable2 = serialPort2.GetNumberOfBytesAvailable();
+
+    ASSERT_EQ(bytesAvailable1, 0);
+    ASSERT_EQ(bytesAvailable2, 0);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortGetAvailableSerialPorts()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    std::vector<std::string> serialPorts1;
+    std::vector<std::string> serialPorts2;
+
+    serialPorts1.clear();
+    serialPorts2.clear();
+
+    serialPorts1 = serialPort1.GetAvailableSerialPorts();
+    serialPorts2 = serialPort2.GetAvailableSerialPorts();
+
+    int portCount1 = (int)serialPorts1.size();
+    int portCount2 = (int)serialPorts2.size();
+
+    ASSERT_GE(portCount1, 2);
+    ASSERT_GE(portCount2, 2);
+    ASSERT_EQ(portCount1, portCount2);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortReadDataBufferWriteDataBuffer()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    const size_t data_count = 75;
+
+    bool timeOutTestPass = false;
+
+    DataBuffer writeVector1;
+    DataBuffer writeVector2;
+
+    DataBuffer readVector1;
+    DataBuffer readVector2;
+
+    // Test using ASCII characters.
+    for (unsigned char i = 0; i < data_count; i++)
+    {
+        writeVector1.push_back((char)(48 + i));
+        writeVector2.push_back((char)(122 - i));
+    }
+
+    serialPort1.Write(writeVector1);
+    serialPort2.Write(writeVector2);
+
+    serialPort1.DrainWriteBuffer();
+    serialPort2.DrainWriteBuffer();
+
+    serialPort1.Read(readVector2, data_count, timeOutMilliseconds);
+    serialPort2.Read(readVector1, data_count, timeOutMilliseconds);
+
+    ASSERT_EQ(readVector1, writeVector1);
+    ASSERT_EQ(readVector2, writeVector2);
+
+    readVector1.clear();
+    readVector2.clear();
+
+    try
+    {
+        serialPort1.Write(writeVector1);
+
+        serialPort1.DrainWriteBuffer();
+
+        serialPort2.Read(readVector1, 0, 75);
+    }
+    catch(...)
+    {
+        timeOutTestPass = true;
+    }
+
+    ASSERT_TRUE(timeOutTestPass);
+    ASSERT_EQ(readVector1, writeVector1);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortReadStringWriteString()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    bool timeOutTestPass = false;
+
+    serialPort1.Write(writeString1);
+    serialPort2.Write(writeString2);
+
+    serialPort1.DrainWriteBuffer();
+    serialPort2.DrainWriteBuffer();
+
+    serialPort1.Read(readString2, writeString2.size(), timeOutMilliseconds);
+    serialPort2.Read(readString1, writeString1.size(), timeOutMilliseconds);
+
+    ASSERT_EQ(readString1, writeString1);
+    ASSERT_EQ(readString2, writeString2);
+
+    timeOutTestPass = false;
+
+    readString1.clear();
+    readString2.clear();
+
+    try
+    {
+        serialPort1.Write(writeString1);
+
+        serialPort1.DrainWriteBuffer();
+
+        serialPort2.Read(readString1, 0, 75);
+    }
+    catch(...)
+    {
+        timeOutTestPass = true;
+    }
+
+    ASSERT_TRUE(timeOutTestPass);
+    ASSERT_EQ(readString1, writeString1);
+    
+    serialPort1.Close();
+    serialPort2.Close();
+    
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortReadByteWriteByte()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    bool timeOutTestPass = false;
+
+    char writeByte1 = 'a';
+    unsigned char writeByte2 = 'A';
+
+    char readByte1  = 'b';
+    unsigned char readByte2  = 'B';
+
+    serialPort1.WriteByte(writeByte1);
+    serialPort2.WriteByte(writeByte2);
+
+    serialPort1.DrainWriteBuffer();
+    serialPort2.DrainWriteBuffer();
+
+    serialPort1.ReadByte(readByte2, timeOutMilliseconds);
+    serialPort2.ReadByte(readByte1, timeOutMilliseconds);
+
+    ASSERT_EQ(readByte1, writeByte1);
+    ASSERT_EQ(readByte2, writeByte2);
+
+    try
+    {
+        serialPort1.ReadByte(readByte1, 1);
+        serialPort2.ReadByte(readByte2, 1);
+    }
+    catch(ReadTimeout)
+    {
+        timeOutTestPass = true;
+    }
+
+    ASSERT_TRUE(timeOutTestPass);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialPortReadLineWriteString()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+
+    ASSERT_TRUE(serialPort1.IsOpen());
+    ASSERT_TRUE(serialPort2.IsOpen());
+
+    bool timeOutTestPass = false;
+
+    serialPort1.Write(writeString1 + '\n');
+    serialPort2.Write(writeString2 + '\n');
+
+    serialPort1.DrainWriteBuffer();
+    serialPort2.DrainWriteBuffer();
+
+    serialPort1.ReadLine(readString2, '\n', timeOutMilliseconds);
+    serialPort2.ReadLine(readString1, '\n', timeOutMilliseconds);
+
+    ASSERT_EQ(readString1, writeString1 + '\n');
+    ASSERT_EQ(readString2, writeString2 + '\n');
+
+    try
+    {
+        serialPort1.ReadLine(readString2, '\n', 1);
+        serialPort2.ReadLine(readString1, '\n', 1);
+    }
+    catch(ReadTimeout)
+    {
+        timeOutTestPass = true;
+    }
+
+    ASSERT_TRUE(timeOutTestPass);
+
+    serialPort1.Close();
+    serialPort2.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialPort2.IsOpen());
+}
+
+void
+LibSerialTest::testSerialStreamToSerialPortReadWrite()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    ASSERT_TRUE(serialPort1.IsOpen());
+
+    serialStream1.Open(TEST_SERIAL_PORT_2);
+    ASSERT_TRUE(serialStream1.IsOpen());
+
+    const auto baud_rate = BaudRate::BAUD_115200 ;
+    serialPort1.SetBaudRate(baud_rate);
+    serialStream1.SetBaudRate(baud_rate);
+
+    BaudRate baudRate1 = serialPort1.GetBaudRate();
+    BaudRate baudRate2 = serialStream1.GetBaudRate();
+
+    ASSERT_EQ(baudRate1, baud_rate);
+    ASSERT_EQ(baudRate2, baud_rate);
+
+    serialStream1 << writeString1 << std::endl;
+    serialPort1.ReadLine(readString1, '\n', timeOutMilliseconds);
+
+    ASSERT_EQ(readString1, writeString1 + '\n');
+    ASSERT_EQ(readString1.size(), writeString1.size() + 1);
+
+    serialPort1.Write(writeString2 + '\n');
+    serialPort1.DrainWriteBuffer();
+    getline(serialStream1, readString2);
+
+    ASSERT_EQ(readString2, writeString2);
+
+    serialPort1.Close();
+    serialStream1.Close();
+
+    ASSERT_FALSE(serialPort1.IsOpen());
+    ASSERT_FALSE(serialStream1.IsOpen());
+}
+
+void
+LibSerialTest::serialStream1ThreadLoop()
+{
+    serialStream1.Open(TEST_SERIAL_PORT_1);
+    serialStream1.SetBaudRate(BaudRate::BAUD_115200);
+    serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    size_t threadLoopStartTimeMilliseconds = getTimeInMilliSeconds();
+    size_t timeElapsedMilliSeconds = 0;
+
+    while (timeElapsedMilliSeconds < timeOutMilliseconds)
+    {
+        serialStream1 << writeString1 << std::endl;
+        serialStream1.DrainWriteBuffer();
+
+        if (serialStream1.IsDataAvailable())
+        {
+            alarm(5);   // Set a system alarm in case getline() blocks longer than 5 seconds.
+            getline(serialStream1, readString2);
+            alarm(0);   // Deactivate the alarm.
+            
+            if(readString2 != writeString2)
+            {
+                mutex.lock();
+                failureRate++;
+                mutex.unlock();
+            }
+        }
+
+        timeElapsedMilliSeconds = getTimeInMilliSeconds() - threadLoopStartTimeMilliseconds;
+
+        mutex.lock();
+        loopCount++;
+        mutex.unlock();
+    }
+
+    serialStream1.Close();
+    return;
+}
+
+void
+LibSerialTest::serialStream2ThreadLoop()
+{
+    serialStream2.Open(TEST_SERIAL_PORT_2);
+    serialStream2.SetBaudRate(BaudRate::BAUD_115200);
+    serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    size_t threadLoopStartTimeMilliseconds = getTimeInMilliSeconds();
+    size_t timeElapsedMilliSeconds = 0;
+
+    while (timeElapsedMilliSeconds < timeOutMilliseconds)
+    {
+        serialStream2 << writeString2 << std::endl;
+        serialStream2.DrainWriteBuffer();
+
+        if (serialStream2.IsDataAvailable())
+        {
+            alarm(5);   // Set a system alarm in case getline() blocks longer than 5 seconds.
+            getline(serialStream2, readString1);
+            alarm(0);   // Deactivate the alarm.
+
+            if(readString1 != writeString1)
+            {
+                mutex.lock();
+                failureRate++;
+                mutex.unlock();
+            }
+        }
+        
+        timeElapsedMilliSeconds = getTimeInMilliSeconds() - threadLoopStartTimeMilliseconds;
+        
+        mutex.lock();
+        loopCount++;
+        mutex.unlock();
+    }
+
+    serialStream2.Close();
+    return;
+}
+
+void
+LibSerialTest::serialPort1ThreadLoop()
+{
+    serialPort1.Open(TEST_SERIAL_PORT_1);
+    serialPort1.SetBaudRate(BaudRate::BAUD_115200);
+    serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    tcflush(serialPort1.GetFileDescriptor(), TCIOFLUSH);
+
+    size_t threadLoopStartTimeMilliseconds = getTimeInMilliSeconds();
+    size_t timeElapsedMilliSeconds = 0;
+
+    while (timeElapsedMilliSeconds < timeOutMilliseconds)
+    {
+       
+        serialPort1.Write(writeString1 + '\n');
+        serialPort1.DrainWriteBuffer();
+
+        if (serialPort1.IsDataAvailable())
+        {
+            try
+            {
+                serialPort1.ReadLine(readString2, '\n', timeOutMilliseconds);
+
+                if(readString2 != writeString2 + '\n')
+                {
+                    mutex.lock();
+                    failureRate++;
+                    mutex.unlock();
+                }
+            }
+            catch(...)
+            {
+            }
+        }
+
+        timeElapsedMilliSeconds = getTimeInMilliSeconds() - threadLoopStartTimeMilliseconds;
+
+        mutex.lock();
+        loopCount++;
+        mutex.unlock();
+    }
+
+    serialPort1.Close();
+    return;
+}
+
+void
+LibSerialTest::serialPort2ThreadLoop()
+{
+    serialPort2.Open(TEST_SERIAL_PORT_2);
+    serialPort2.SetBaudRate(BaudRate::BAUD_115200);
+    serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE);
+
+    tcflush(serialPort1.GetFileDescriptor(), TCIOFLUSH);
+
+    size_t threadLoopStartTimeMilliseconds = getTimeInMilliSeconds();
+    size_t timeElapsedMilliSeconds = 0;
+
+    while (timeElapsedMilliSeconds < timeOutMilliseconds)
+    {
+        serialPort2.Write(writeString2 + '\n');
+        serialPort2.DrainWriteBuffer();
+
+        if (serialPort2.IsDataAvailable())
+        {
+            try
+            {
+                serialPort2.ReadLine(readString1, '\n', timeOutMilliseconds);
+
+                if(readString1 != writeString1 + '\n')
+                {
+                    mutex.lock();
+                    failureRate++;
+                    mutex.unlock();
+                }
+            }
+            catch(...)
+            {
+            }
+        }
+
+        timeElapsedMilliSeconds = getTimeInMilliSeconds() - threadLoopStartTimeMilliseconds;
+
+        mutex.lock();
+        loopCount++;
+        mutex.unlock();
+    }
+
+    serialPort2.Close();
+    return;
+}
+
+void
+LibSerialTest::testMultiThreadSerialStreamReadWrite()
+{
+    failureRate = 0;
+    loopCount = 0;
+
+    std::thread serialStream1Thread(&LibSerialTest::serialStream1ThreadLoop, this);
+    std::thread serialStream2Thread(&LibSerialTest::serialStream2ThreadLoop, this);
+
+    serialStream1Thread.join();
+    serialStream2Thread.join();
+}
+
+void
+LibSerialTest::testMultiThreadSerialPortReadWrite()
+{
+    failureRate = 0;
+    loopCount = 0;
+    
+    std::thread serialPort1Thread(&LibSerialTest::serialPort1ThreadLoop, this);
+    std::thread serialPort2Thread(&LibSerialTest::serialPort2ThreadLoop, this);
+
+    serialPort1Thread.join();
+    serialPort2Thread.join();
+}
 
 
 //------------------------ Serial Stream Unit Tests -------------------------//

--- a/test/UnitTests.h
+++ b/test/UnitTests.h
@@ -1,0 +1,475 @@
+/******************************************************************************
+ *   @file LibSerialTest.cpp                                                  *
+ *   @copyright (C) 2016 LibSerial Development Team                           *
+ *                                                                            *
+ *   This program is free software; you can redistribute it and/or modify     *
+ *   it under the terms of the GNU Lessser General Public License as          *
+ *   published by the Free Software Foundation; either version 2 of the       *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   This program is distributed in the hope that it will be useful,          *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with this program; if not, write to the                    *
+ *   Free Software Foundation, Inc.,                                          *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.                *
+ *****************************************************************************/
+
+#include "SerialPort.h"
+#include "SerialPortConstants.h"
+#include "SerialStream.h"
+
+
+// Default Serial Ports.
+#define TEST_SERIAL_PORT_1 "/dev/ttyUSB0"
+#define TEST_SERIAL_PORT_2 "/dev/ttyUSB1"
+
+namespace LibSerial
+{
+    class LibSerialTest : public ::testing::Test
+    {
+    public:
+
+        /**
+         * @brief Default Constructor.
+         */
+        explicit LibSerialTest();
+
+        /**
+         * @brief Default Destructor.
+         */
+        virtual ~LibSerialTest();
+
+        /**
+         * @param The number of iterations to perform on each unit test.
+         */
+        size_t numberOfTestIterations = 10;
+
+    protected:
+
+        /**
+         * @brief Method for performing an required test initializations.
+         */
+        virtual void SetUp();
+
+        /**
+         * @brief Gets the time since epoch in milliseconds.
+         * @return Returns the time since epoch in milliseconds
+         */
+        size_t getTimeInMilliSeconds();
+        
+        /**
+         * @brief Gets the time since epoch in microseconds.
+         * @return Returns the time since epoch in microseconds
+         */
+        size_t getTimeInMicroSeconds();
+
+        //---------------------- Serial Stream Unit Tests -----------------------//
+
+        /**
+         * @brief Tests constructor overloads and destructors.
+         */
+        void testSerialStreamConstructors();
+
+        /**
+         * @brief Tests correct functionality for opening and closing serial streams.
+         */
+        void testSerialStreamOpenClose();
+
+        /**
+         * @brief Tests correct functionality for draining the hardware write buffer using tcdrain().
+         */
+        void testSerialStreamDrainWriteBuffer();
+
+        /**
+         * @brief Tests correct functionality for draining the hardware input (read) buffer using tcflush();
+         */
+        void testSerialStreamFlushInputBuffer();
+
+        /**
+         * @brief Tests correct functionality for draining the hardware write buffer using tcflush();
+         */
+        void testSerialStreamFlushOutputBuffer();
+
+        /**
+         * @brief Tests correct functionality for draining the hardware read/write buffers using tcflush();
+         */
+        void testSerialStreamFlushIOBuffers();
+
+        /**
+         * @brief Tests correct functionality for checking if data is available.
+         */
+        void testSerialStreamIsDataAvailableTest();
+
+        /**
+         * @brief Tests for correct functionality of the Open() and Close() methods.
+         */
+        void testSerialStreamIsOpenTest();
+
+        /**
+         * @brief Tests for correct functionality of the SetBaudRate() and GetBaudRate() methods.
+         */
+        void testSerialStreamSetGetBaudRate();
+
+        /**
+         * @brief Tests for correct functionality of the SetCharacterSize() and GetCharactersize() methods.
+         */
+        void testSerialStreamSetGetCharacterSize();
+
+        /**
+         * @brief Tests for correct functionality of the SetFlowControl() and GetFlowControl() methods.
+         */
+        void testSerialStreamSetGetFlowControl();
+
+        /**
+         * @brief Tests for correct functionality of the SetParity() and GetParity() methods.
+         */
+        void testSerialStreamSetGetParity();
+
+        /**
+         * @brief Tests for correct functionality of the SetStopBits() and GetStopBits() methods.
+         */
+        void testSerialStreamSetGetStopBits();
+
+        /**
+         * @brief Tests for correct functionality of the SetVMin() and GetVMin() methods.
+         */
+        void testSerialStreamSetGetVMin();
+
+        /**
+         * @brief Tests for correct functionality of the SetVTime() and GetVMin() methods.
+         */
+        void testSerialStreamSetGetVTime();
+
+        /**
+         * @brief Tests for correct functionality of the SetDTR() and GetDTR() methods.
+         */
+        void testSerialStreamSetGetDTR();
+
+        /**
+         * @brief Tests for correct functionality of the SetRTS() and GetRTS() methods.
+         */
+        void testSerialStreamSetGetRTS();
+
+        /**
+         * @brief Tests for correct functionality of the SetRTS() and GetCTS() methods.
+         */
+        void testSerialStreamSetRTSGetCTS();
+
+        /**
+         * @brief Tests for correct functionality of the SetDTR() and GetDSR() methods.
+         */
+        void testSerialStreamSetDTRGetDSR();
+
+        /**
+         * @brief Tests for correct functionality of the GetFileDescriptor() method.
+         */
+        void testSerialStreamGetFileDescriptor();
+
+        /**
+         * @brief Tests for correct functionality of the GetNumberOfBytesAvailable() method.
+         */
+        void testSerialStreamGetNumberOfBytesAvailable();
+
+        /**
+         * @brief Tests for correct functionality of the GetAvailableSerialPorts() method.
+         */
+        void testSerialStreamGetAvailableSerialPorts();
+
+        /**
+         * @brief Tests for correct functionality of the ReadByte() and WriteByte() methods.
+         */
+        void testSerialStreamReadByteWriteByte();
+
+        /**
+         * @brief Tests for correct functionality of the GetLine() and WriteString() methods.
+         */
+        void testSerialStreamGetLineWriteString();
+
+        /**
+         * @brief Tests for correct functionality of the Get() and WriteByte() methods.
+         */
+        void testSerialStreamGetWriteByte();
+
+
+        //----------------------- Serial Port Unit Tests ------------------------//
+
+        /**
+         * @brief Tests constructor overloads and destructors.
+         */
+        void testSerialPortConstructors();
+
+        /**
+         * @brief Tests correct functionality for opening and closing serial ports.
+         */
+        void testSerialPortOpenClose();
+
+        /**
+         * @brief Tests correct functionality for draining the hardware write buffer using tcdrain().
+         */
+        void testSerialPortDrainWriteBuffer();
+
+        /**
+         * @brief Tests correct functionality for draining the hardware input (read) buffer using tcflush();
+         */
+        void testSerialPortFlushInputBuffer();
+
+        /**
+         * @brief Tests correct functionality for draining the hardware write buffer using tcflush();
+         */
+        void testSerialPortFlushOutputBuffer();
+
+        /**
+         * @brief Tests correct functionality for draining the hardware read/write buffers using tcflush();
+         */
+        void testSerialPortFlushIOBuffers();
+
+        /**
+         * @brief Tests correct functionality for checking if data is available.
+         */
+        void testSerialPortIsDataAvailableTest();
+
+        /**
+         * @brief Tests for correct functionality of the Open() and Close() methods.
+         */
+        void testSerialPortIsOpenTest();
+
+        /**
+         * @brief Tests for correct functionality of the SetBaudRate() and GetBaudRate() methods.
+         */
+        void testSerialPortSetGetBaudRate();
+
+        /**
+         * @brief Tests for correct functionality of the SetCharacterSize() and GetCharactersize() methods.
+         */
+        void testSerialPortSetGetCharacterSize();
+
+        /**
+         * @brief Tests for correct functionality of the SetFlowControl() and GetFlowControl() methods.
+         */
+        void testSerialPortSetGetFlowControl();
+
+        /**
+         * @brief Tests for correct functionality of the SetParity() and GetParity() methods.
+         */
+        void testSerialPortSetGetParity();
+
+        /**
+         * @brief Tests for correct functionality of the SetStopBits() and GetStopBits() methods.
+         */
+        void testSerialPortSetGetStopBits();
+
+        /**
+         * @brief Tests for correct functionality of the SetVMin() and GetVMin() methods.
+         */
+        void testSerialPortSetGetVMin();
+
+        /**
+         * @brief Tests for correct functionality of the SetVTime() and GetVMin() methods.
+         */
+        void testSerialPortSetGetVTime();
+
+        /**
+         * @brief Tests for correct functionality of the SetDTR() and GetDTR() methods.
+         */
+        void testSerialPortSetGetDTR();
+
+        /**
+         * @brief Tests for correct functionality of the SetRTS() and GetRTS() methods.
+         */
+        void testSerialPortSetGetRTS();
+
+        /**
+         * @brief Tests for correct functionality of the SetRTS() and GetCTS() methods.
+         */
+        void testSerialPortSetRTSGetCTS();
+
+        /**
+         * @brief Tests for correct functionality of the SetDTR() and GetDSR() methods.
+         */
+        void testSerialPortSetDTRGetDSR();
+
+        /**
+         * @brief Tests for correct functionality of the GetFileDescriptor() method.
+         */
+        void testSerialPortGetFileDescriptor();
+
+        /**
+         * @brief Tests for correct functionality of the GetNumberOfBytesAvailable() method.
+         */
+        void testSerialPortGetNumberOfBytesAvailable();
+
+        /**
+         * @brief Tests for correct functionality of the GetAvailableSerialPorts() method.
+         */
+        void testSerialPortGetAvailableSerialPorts();
+
+        /**
+         * @brief Tests for correct functionality of the ReadDataBuffer() and WriteDataBuffer() methods.
+         */
+        void testSerialPortReadDataBufferWriteDataBuffer();
+
+        /**
+         * @brief Tests for correct functionality of the ReadString() and WriteString() methods.
+         */
+        void testSerialPortReadStringWriteString();
+
+        /**
+         * @brief Tests for correct functionality of the ReadByte() and WriteByte() methods.
+         */
+        void testSerialPortReadByteWriteByte();
+
+        /**
+         * @brief Tests for correct functionality of the ReadLine() and WriteString() methods.
+         */
+        void testSerialPortReadLineWriteString();
+
+        /**
+         * @brief Tests for correct functionality for writing data from a serial stream object and reading that data from a serial port object..
+         */
+        void testSerialStreamToSerialPortReadWrite();
+
+        //--------------------- Multi-Thread Unit Tests ---------------------//
+
+        /**
+         * @brief Tests for correct functionality of a multi-threaded serial stream application.
+         */
+        void serialStream1ThreadLoop();
+
+        /**
+         * @brief Tests for correct functionality of a multi-threaded serial port application.
+         */
+        void serialStream2ThreadLoop();
+
+        /**
+         * @brief Main loop for the multi-threaded serial stream unit test.
+         */
+        void serialPort1ThreadLoop();
+
+        /**
+         * @brief Main loop for the multi-threaded serial port unit test.
+         */
+        void serialPort2ThreadLoop();
+
+        /**
+         * @brief Entry point for the multi-thread serial stream unit test.
+         */
+        void testMultiThreadSerialStreamReadWrite();
+
+        /**
+         * @brief Entry point for the multi-thread serial port unit test.
+         */
+        void testMultiThreadSerialPortReadWrite();
+
+        //---------------------- Unit Tests Parameters ----------------------//
+
+        /**
+         * @param C++11 thread std::mutex for locking parameters in the threaded unit tests.
+         */
+        std::mutex mutex;
+
+        /**
+         * @param Time since epoch at entry of a method.
+         */
+        size_t entryTime;
+
+        /**
+         * @param Current time since epoch during execution of a method.
+         */
+        size_t currentTime;
+
+        /**
+         * @param Time elapsed during execution of a method.
+         */
+        size_t elapsedTime;
+
+        /**
+         * @param Failure rate of serial communications being tracked in the threaded tests.
+         */
+        size_t failureRate;
+
+        /**
+         * @param Loop count variable.
+         */
+        size_t loopCount;
+
+        /**
+         * @param Timeout to be used for test methods.
+         */
+        size_t timeOutMilliseconds;
+
+        /**
+         * @param Time to allow the hardware read buffer to fill or empty.
+         */
+        unsigned int readBufferDelay;
+
+        /**
+         * @struct Standard baud rates.
+         */
+        std::vector<LibSerial::BaudRate> baudRates;
+
+        /**
+         * @struct Standard character sizes.
+         */
+        std::vector<LibSerial::CharacterSize> characterSizes;
+
+        /**
+         * @struct Standard flow control types.
+         */
+        std::vector<LibSerial::FlowControl> flowControlTypes;
+
+        /**
+         * @struct Standard flow parity types.
+         */
+        std::vector<LibSerial::Parity> parityTypes;
+
+        /**
+         * @struct Standard number of stop bits.
+         */
+        std::vector<LibSerial::StopBits> stopBits;
+
+        /**
+         * @param Serial Stream instance 1 for unit testing applications.
+         */
+        LibSerial::SerialStream serialStream1;
+
+        /**
+         * @param Serial Stream instance 2 for unit testing applications.
+         */
+        LibSerial::SerialStream serialStream2;
+
+        /**
+         * @param Serial Port instance 1 for unit testing applications.
+         */
+        LibSerial::SerialPort serialPort1;
+
+        /**
+         * @param Serial Port instance 2 for unit testing applications.
+         */
+        LibSerial::SerialPort serialPort2;
+
+        /**
+         * @param String to store received data.
+         */
+        std::string readString1;
+
+        /**
+         * @param String to store received data.
+         */
+        std::string readString2;
+
+        /**
+         * @param String to store data to be written to the serial port.
+         */
+        std::string writeString1;
+
+        /**
+         * @param String to store data to be written to the serial port.
+         */
+        std::string writeString2;
+
+    };
+}

--- a/test/UnitTests.h
+++ b/test/UnitTests.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- *   @file LibSerialTest.cpp                                                  *
+ *   @file UnitTest.h                                                         *
  *   @copyright (C) 2016 LibSerial Development Team                           *
  *                                                                            *
  *   This program is free software; you can redistribute it and/or modify     *
@@ -23,10 +23,19 @@
 #include "SerialStream.h"
 
 
-// Default Serial Ports.
+/**
+ * @brief Default Serial Port 1.
+ */
 #define TEST_SERIAL_PORT_1 "/dev/ttyUSB0"
+
+/**
+ * @brief Default Serial Port 2.
+ */
 #define TEST_SERIAL_PORT_2 "/dev/ttyUSB1"
 
+/**
+ * @namespace Libserial
+ */
 namespace LibSerial
 {
     class LibSerialTest : public ::testing::Test


### PR DESCRIPTION
Hi CrayzeeWulf,

I cut appropriate sections of code out of the UnitTests.cpp file into a header file in this merge request.

Appropriate testing using both the make build and cmake build has been conducted with all previous functionality preserved.  Doxy documentation has allso been completed for the header file.

Please let me know if you have any questions on this PR!

-Mark  