### PR TITLE
Added c++11 compiler flag per Jeffrey Franks patch instructions.

### DIFF
--- a/sip/configure.py.in
+++ b/sip/configure.py.in
@@ -51,6 +51,10 @@ def main():
                                             threaded=1,
                                             makefile="Makefile.sip" )
     #
+    # Add extra cxxflags to be passed to C++ compiler
+    #
+    makefile.extra_cxxflags = [ "-std=c++11" ]
+    #
     # Add the library we are wrapping.  The name doesn't include any platform
     # specific prefixes or extensions (e.g. the "lib" prefix on UNIX, or the
     # ".dll" extension on Windows).


### PR DESCRIPTION
Hello!

This PR adds c++11 compiler flags to the sip/configure.py.in script to fix a compiler error encountered by Jeff Franks.

Let me know if you have any questions on this PR!

-Mark