### PR TITLE
SerialPort.cpp: fix build when size_t is an unsigned int

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -2208,7 +2208,7 @@ namespace LibSerial
 
         // Local variables.
         size_t number_of_bytes_read = 0 ;
-        size_t number_of_bytes_remaining = std::max(numberOfBytes, 1UL) ;
+        size_t number_of_bytes_remaining = std::max(numberOfBytes, size_t {1}) ;
         size_t maximum_number_of_bytes = dataBuffer.max_size() ;
         
         // Clear the data buffer and reserve enough space in the buffer to store the incoming data.
@@ -2302,7 +2302,7 @@ namespace LibSerial
 
         // Local variables.
         size_t number_of_bytes_read = 0 ;
-        size_t number_of_bytes_remaining = std::max(numberOfBytes, 1UL) ;
+        size_t number_of_bytes_remaining = std::max(numberOfBytes, size_t {1}) ;
         size_t maximum_number_of_bytes = dataString.max_size() ;
         
         // Clear the data buffer and reserve enough space in the buffer to store the incoming data.


### PR DESCRIPTION
size_t can be defined as an unsigned int instead of long unsigned int so
replace 1UL to (size_t)1 when calling max function

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>