### PR TITLE
SerialPort.cpp: don't use high baudrates when not available

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -1223,6 +1223,7 @@ namespace LibSerial
             baud_rate_as_int = 1500000 ;
             break ;
 
+#if __MAX_BAUD > B2000000
         case BaudRate::BAUD_2000000:
             baud_rate_as_int = 2000000 ;
             break ;
@@ -1242,6 +1243,7 @@ namespace LibSerial
         case BaudRate::BAUD_4000000:
             baud_rate_as_int = 4000000 ;
             break ;
+#endif /* __MAX_BAUD */
         default:
             // If an incorrect baud rate was specified, throw an exception.
             throw std::runtime_error(ERR_MSG_INVALID_BAUD_RATE) ;


### PR DESCRIPTION
On certain architectures (namely Sparc), the maximum baud rate exposed
by the kernel headers is B2000000. Therefore, the current libserial
code doesn't build for the Sparc and Sparc64 architectures due to
this.

In order to address this problem, this patch tests the value of
__MAX_BAUD. If it's higher than B2000000 then we assume we're on an
architecture that supports all baud rates up to B4000000. Otherwise,
we simply don't support the baud rates above B2000000.

Fixes build failures such as:

SerialPort.cpp: In member function 'int LibSerial::SerialPort::Implementation::GetBitRate(const LibSerial::BaudRate&) const':
SerialPort.cpp:1226:14: error: 'BAUD_2000000' is not a member of 'LibSerial::BaudRate'
         case BaudRate::BAUD_2000000:

Fixes:
 - http://autobuild.buildroot.org/results/63ba95b6786464fa8e75af64593010df84530079

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>