### PR TITLE
Added check for linux specific baud rates to SerialPort.cpp.

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -1195,6 +1195,8 @@ namespace LibSerial
             baud_rate_as_int = 230400 ;
             break ;
 
+// @note: >B230400 are defined in Linux but not other POSIX systems, (e.g. Mac OS X).
+#ifdef __linux__
         case BaudRate::BAUD_460800:
             baud_rate_as_int = 460800 ;
             break ;
@@ -1243,7 +1245,8 @@ namespace LibSerial
         case BaudRate::BAUD_4000000:
             baud_rate_as_int = 4000000 ;
             break ;
-#endif /* __MAX_BAUD */
+#endif // __MAX_BAUD
+#endif // __linux__
         default:
             // If an incorrect baud rate was specified, throw an exception.
             throw std::runtime_error(ERR_MSG_INVALID_BAUD_RATE) ;

--- a/src/libserial/SerialPortConstants.h
+++ b/src/libserial/SerialPortConstants.h
@@ -207,7 +207,7 @@ namespace LibSerial
         BAUD_115200  = B115200,
         BAUD_230400  = B230400,
 
-        // @note: >B230400 are defined in Linux but not other POSIX systems, (e.g. Mac OS X).
+// @note: >B230400 are defined in Linux but not other POSIX systems, (e.g. Mac OS X).
 #ifdef __linux__
         BAUD_460800  = B460800,
         BAUD_500000  = B500000,
@@ -222,8 +222,8 @@ namespace LibSerial
         BAUD_3000000 = B3000000,
         BAUD_3500000 = B3500000,
         BAUD_4000000 = B4000000,
-#endif /* __MAX_BAUD */
-#endif /* __linux__ */
+#endif // __MAX_BAUD
+#endif // __linux__
         BAUD_DEFAULT = BAUD_115200,
         BAUD_INVALID = std::numeric_limits<speed_t>::max()
     } ;


### PR DESCRIPTION
Hi Crayzee Wulf,

This PR just adds in a check to SerialPort.cpp for linux specific baud rates in following the discussion from PR #127 .  It also modifies the comment style to single line rather than block as is done in other instances in libserial.

This PR passes hardware testing on an Ubuntu 18.10 machine with FTDI USB to serial port hardware adapters.

Please let me know if you have any questions on this PR!

-Mark