### PR TITLE
Added try/catch blocks to the serial port and serial stream Open() calls and #defines for port names.

### DIFF
--- a/examples/serial_port_read.cpp
+++ b/examples/serial_port_read.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <unistd.h>
 
+#define DEFAULT_SERIAL_PORT_0 "/dev/ttyUSB0"
 
 /**
  * @brief This example demonstrates configuring a serial port and 
@@ -21,8 +22,16 @@ int main()
     // Instantiate a SerialPort object.
     SerialPort serial_port ;
 
-    // Open the Serial Port at the desired hardware port.
-    serial_port.Open("/dev/ttyUSB0") ;
+    try
+    {
+        // Open the Serial Port at the desired hardware port.
+        serial_port.Open(DEFAULT_SERIAL_PORT_0) ;
+    }
+    catch (OpenFailed&)
+    {
+        std::cerr << "The serial port did not open correctly." << std::endl ;
+        return EXIT_FAILURE ;
+    }
 
     // Set the baud rate of the serial port.
     serial_port.SetBaudRate(BaudRate::BAUD_115200) ;

--- a/examples/serial_port_read_write.cpp
+++ b/examples/serial_port_read_write.cpp
@@ -158,7 +158,8 @@ int main()
         std::getline(std::cin, user_input) ;
 
         if (user_input == "q" ||
-            user_input == "Q")
+            user_input == "Q" ||
+            user_input == "")
         {
             break ;
         }

--- a/examples/serial_port_read_write.cpp
+++ b/examples/serial_port_read_write.cpp
@@ -9,6 +9,9 @@
 #include <iostream>
 #include <unistd.h>
 
+#define DEFAULT_SERIAL_PORT_0 "/dev/ttyUSB0"
+#define DEFAULT_SERIAL_PORT_1 "/dev/ttyUSB1"
+
 /**
  * @brief This example demonstrates multiple methods to read and write
  *        serial stream data.
@@ -16,17 +19,18 @@
 int main()
 {
     using namespace LibSerial ;
+
     // Instantiate two SerialPort objects.
     SerialPort serial_port_1 ;
     SerialPort serial_port_2 ;
 
-    // Open the Serial Ports at the desired hardware devices.
-    serial_port_1.Open("/dev/ttyUSB0") ;
-    serial_port_2.Open("/dev/ttyUSB1") ;
-
-    // Verify that the serial ports opened.
-    if (!serial_port_1.IsOpen() ||
-        !serial_port_2.IsOpen())
+    try
+    {
+        // Open the Serial Ports at the desired hardware devices.
+        serial_port_1.Open(DEFAULT_SERIAL_PORT_0) ;
+        serial_port_2.Open(DEFAULT_SERIAL_PORT_1) ;
+    }
+    catch (OpenFailed&)
     {
         std::cerr << "The serial ports did not open correctly." << std::endl ;
         return EXIT_FAILURE ;

--- a/examples/serial_port_write.cpp
+++ b/examples/serial_port_write.cpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <iostream>
 
+#define DEFAULT_SERIAL_PORT_1 "/dev/ttyUSB1"
+
 
 /**
  * @brief This example reads the contents of a file and writes the entire 
@@ -42,8 +44,16 @@ int main(int argc, char** argv)
     // Instantiate a SerialPort object.
     SerialPort serial_port ;
 
-    // Open the Serial Port at the desired hardware port.
-    serial_port.Open("/dev/ttyUSB1") ;
+    try
+    {
+        // Open the Serial Port at the desired hardware port.
+        serial_port.Open(DEFAULT_SERIAL_PORT_1) ;
+    }
+    catch (OpenFailed&)
+    {
+        std::cerr << "The serial port did not open correctly." << std::endl ;
+        return EXIT_FAILURE ;
+    }
 
     // Set the baud rate of the serial port.
     serial_port.SetBaudRate(BaudRate::BAUD_115200) ;

--- a/examples/serial_stream_read.cpp
+++ b/examples/serial_stream_read.cpp
@@ -8,6 +8,8 @@
 #include <iostream>
 #include <unistd.h>
 
+#define DEFAULT_SERIAL_PORT_0 "/dev/ttyUSB0"
+
 /**
  * @brief This example demonstrates configuring a serial stream and 
  *        reading serial stream data.
@@ -15,11 +17,20 @@
 int main()
 {
     using namespace LibSerial ;
+
     // Instantiate a SerialStream object.
     SerialStream serial_stream ;
 
-    // Open the Serial Port at the desired hardware port.
-    serial_stream.Open("/dev/ttyUSB0") ;
+    try
+    {
+        // Open the Serial Port at the desired hardware port.
+        serial_stream.Open(DEFAULT_SERIAL_PORT_0) ;
+    }
+    catch (OpenFailed&)
+    {
+        std::cerr << "The serial port did not open correctly." << std::endl ;
+        return EXIT_FAILURE ;
+    }
 
     // Set the baud rate of the serial port.
     serial_stream.SetBaudRate(BaudRate::BAUD_115200) ;

--- a/examples/serial_stream_read_write.cpp
+++ b/examples/serial_stream_read_write.cpp
@@ -10,6 +10,9 @@
 #include <iostream>
 #include <unistd.h>
 
+#define DEFAULT_SERIAL_PORT_0 "/dev/ttyUSB0"
+#define DEFAULT_SERIAL_PORT_1 "/dev/ttyUSB1"
+
 /**
  * @brief This example demonstrates multiple methods to read and write
  *        serial stream data utilizing std::iostream functionality.
@@ -17,17 +20,18 @@
 int main()
 {
     using namespace LibSerial ;
+
     // Instantiate two SerialStream objects.
     SerialStream serial_stream_1 ;
     SerialStream serial_stream_2 ;
 
-    // Open the Serial Ports at the desired hardware devices.
-    serial_stream_1.Open("/dev/ttyUSB0") ;
-    serial_stream_2.Open("/dev/ttyUSB1") ;
-
-    // Verify that the serial ports opened.
-    if (!serial_stream_1.IsOpen() ||
-        !serial_stream_2.IsOpen())
+    try
+    {
+        // Open the Serial Ports at the desired hardware devices.
+        serial_stream_1.Open(DEFAULT_SERIAL_PORT_0) ;
+        serial_stream_2.Open(DEFAULT_SERIAL_PORT_1) ;
+    }
+    catch (OpenFailed&)
     {
         std::cerr << "The serial ports did not open correctly." << std::endl ;
         return EXIT_FAILURE ;

--- a/examples/serial_stream_read_write.cpp
+++ b/examples/serial_stream_read_write.cpp
@@ -132,7 +132,8 @@ int main()
         std::getline(std::cin, user_input) ;
 
         if (user_input == "q" ||
-            user_input == "Q")
+            user_input == "Q" ||
+            user_input == "")
         {
             break ;
         }

--- a/examples/serial_stream_write.cpp
+++ b/examples/serial_stream_write.cpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <iostream>
 
+#define DEFAULT_SERIAL_PORT_1 "/dev/ttyUSB1"
+
 /**
  * @brief This example reads the contents of a file and writes the entire 
  *        file to the serial port one character at a time. To use this
@@ -41,8 +43,16 @@ int main(int argc, char** argv)
     // Instantiate a SerialStream object.
     SerialStream serial_stream ;
 
-    // Open the Serial Port at the desired hardware port.
-    serial_stream.Open("/dev/ttyUSB1") ;
+    try
+    {
+        // Open the Serial Port at the desired hardware port.
+        serial_stream.Open(DEFAULT_SERIAL_PORT_1) ;
+    }
+    catch (OpenFailed&)
+    {
+        std::cerr << "The serial port did not open correctly." << std::endl ;
+        return EXIT_FAILURE ;
+    }
 
     // Set the baud rate of the serial port.
     serial_stream.SetBaudRate(BaudRate::BAUD_115200) ;


### PR DESCRIPTION
Hi Crayzee Wulf,

This PR adds try/catch blocks around the Open() calls in the example code. (Making the assumption that is probably the most likely place for an early example failure to occur.)

I've also added `#define`'s for the port names so that readers will hopefully have an easier time spotting them and modifying them.

Let me know if you'd like to see anything done differently here and I will gladly carry it out!

-Mark 

EDIT: Hardware tests have been verified passing on all example tests