### PR TITLE
Update the README and standardize SERIAL_PORT_1 and SERIAL_PORT_2 declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,29 +82,43 @@ make
 sudo make install
 ```
 
+### Example Code and Unit Tests
 ----
-If you are interested in running the unit tests, ensure serial port names are appropriate for your hardware configuration in the `test/UnitTests.cpp` file:
+If you are interested in running the unit tests or example code, ensure serial port names are appropriate for your hardware configuration in the `examples/` directory files and in the `test/UnitTests.h` file as such:
 
 ```cpp
-#define TEST_SERIAL_PORT_1 "/dev/ttyUSB0"
-#define TEST_SERIAL_PORT_2 "/dev/ttyUSB1"
+constexpr const char* const SERIAL_PORT_1 = "/dev/ttyUSB0" ;
+constexpr const char* const SERIAL_PORT_2 = "/dev/ttyUSB1" ;
 ```
 
-The unit tests will be built during the make steps above or by running the cmake compile script:
+Example code and Unit test executables are easily built using the cmake compile script and can be run from the `build` directory:
 
 ```sh
-./compile.sh
+./compile
+```
+```sh
+./build/bin/UnitTests
+```
+```sh
+./build/bin/SerialPortReadWriteExample
 ```
 
-Unit test executables built using make can be run from the `build` directory using the command:
+Unit test executables built using make can be run from the `build` directory in the following manner:
 ```sh
 ctest -V .
 ```
 
-Alternatively, unit test executables built using CMake can be run from the libserial/build/bin/ directory:
+#### Hardware and Software Considerations:
+If needed, you can grant user permissions to utilize the hardware ports in the following manner, (afterwards a reboot is required):
 ```sh
-./build/bin/UnitTests
-./build/bin/unit_tests
+sudo usermod -a -G dialout $USER
+sudo usermod -a -G plugdev $USER
+```
+
+##### Socat
+Socat is a useful tool to allow hardware ports to communicate on the same system via a software pipe.  As an example, to allow hardware UART port `/dev/ttyS0` to communicate via software with hardware UART port `/dev/ttyS1`:
+```sh
+socat -d -d pty,raw,echo=0,link=/dev/ttyS0 pty,raw,echo=0,link=/dev/ttyS1
 ```
 
 ----

--- a/examples/main_page_example.cpp
+++ b/examples/main_page_example.cpp
@@ -7,6 +7,9 @@
 
 #include <iostream>
 
+constexpr const char* const SERIAL_PORT_1 = "/dev/ttyUSB0" ;
+constexpr const char* const SERIAL_PORT_2 = "/dev/ttyUSB1" ;
+
 int main()
 {
     using LibSerial::SerialPort ;
@@ -17,8 +20,8 @@ int main()
     SerialStream serial_stream ;
 
     // Open the hardware serial ports.
-    serial_port.Open( "/dev/ttyUSB0" ) ;
-    serial_stream.Open( "/dev/ttyUSB1" ) ;
+    serial_port.Open( SERIAL_PORT_1 ) ;
+    serial_stream.Open( SERIAL_PORT_2 ) ;
 
     // Set the baud rates.
     using LibSerial::BaudRate ;

--- a/examples/serial_port_read.cpp
+++ b/examples/serial_port_read.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <unistd.h>
 
-#define DEFAULT_SERIAL_PORT_0 "/dev/ttyUSB0"
+constexpr const char* const SERIAL_PORT_1 = "/dev/ttyUSB0" ;
 
 /**
  * @brief This example demonstrates configuring a serial port and 
@@ -25,7 +25,7 @@ int main()
     try
     {
         // Open the Serial Port at the desired hardware port.
-        serial_port.Open(DEFAULT_SERIAL_PORT_0) ;
+        serial_port.Open(SERIAL_PORT_1) ;
     }
     catch (const OpenFailed&)
     {

--- a/examples/serial_port_read_write.cpp
+++ b/examples/serial_port_read_write.cpp
@@ -9,8 +9,8 @@
 #include <iostream>
 #include <unistd.h>
 
-#define DEFAULT_SERIAL_PORT_0 "/dev/ttyUSB0"
-#define DEFAULT_SERIAL_PORT_1 "/dev/ttyUSB1"
+constexpr const char* const SERIAL_PORT_1 = "/dev/ttyUSB0" ;
+constexpr const char* const SERIAL_PORT_2 = "/dev/ttyUSB1" ;
 
 /**
  * @brief This example demonstrates multiple methods to read and write
@@ -27,8 +27,8 @@ int main()
     try
     {
         // Open the Serial Ports at the desired hardware devices.
-        serial_port_1.Open(DEFAULT_SERIAL_PORT_0) ;
-        serial_port_2.Open(DEFAULT_SERIAL_PORT_1) ;
+        serial_port_1.Open(SERIAL_PORT_1) ;
+        serial_port_2.Open(SERIAL_PORT_2) ;
     }
     catch (const OpenFailed&)
     {

--- a/examples/serial_port_write.cpp
+++ b/examples/serial_port_write.cpp
@@ -8,8 +8,7 @@
 #include <fstream>
 #include <iostream>
 
-#define DEFAULT_SERIAL_PORT_1 "/dev/ttyUSB1"
-
+constexpr const char* const SERIAL_PORT_2 = "/dev/ttyUSB1" ;
 
 /**
  * @brief This example reads the contents of a file and writes the entire 
@@ -47,7 +46,7 @@ int main(int argc, char** argv)
     try
     {
         // Open the Serial Port at the desired hardware port.
-        serial_port.Open(DEFAULT_SERIAL_PORT_1) ;
+        serial_port.Open(SERIAL_PORT_2) ;
     }
     catch (const OpenFailed&)
     {

--- a/examples/serial_stream_read.cpp
+++ b/examples/serial_stream_read.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <unistd.h>
 
-#define DEFAULT_SERIAL_PORT_0 "/dev/ttyUSB0"
+constexpr const char* const SERIAL_PORT_1 = "/dev/ttyUSB0" ;
 
 /**
  * @brief This example demonstrates configuring a serial stream and 
@@ -24,7 +24,7 @@ int main()
     try
     {
         // Open the Serial Port at the desired hardware port.
-        serial_stream.Open(DEFAULT_SERIAL_PORT_0) ;
+        serial_stream.Open(SERIAL_PORT_1) ;
     }
     catch (const OpenFailed&)
     {

--- a/examples/serial_stream_read_write.cpp
+++ b/examples/serial_stream_read_write.cpp
@@ -10,8 +10,8 @@
 #include <iostream>
 #include <unistd.h>
 
-#define DEFAULT_SERIAL_PORT_0 "/dev/ttyUSB0"
-#define DEFAULT_SERIAL_PORT_1 "/dev/ttyUSB1"
+constexpr const char* const SERIAL_PORT_1 = "/dev/ttyUSB0" ;
+constexpr const char* const SERIAL_PORT_2 = "/dev/ttyUSB1" ;
 
 /**
  * @brief This example demonstrates multiple methods to read and write
@@ -28,8 +28,8 @@ int main()
     try
     {
         // Open the Serial Ports at the desired hardware devices.
-        serial_stream_1.Open(DEFAULT_SERIAL_PORT_0) ;
-        serial_stream_2.Open(DEFAULT_SERIAL_PORT_1) ;
+        serial_stream_1.Open(SERIAL_PORT_1) ;
+        serial_stream_2.Open(SERIAL_PORT_2) ;
     }
     catch (const OpenFailed&)
     {

--- a/examples/serial_stream_write.cpp
+++ b/examples/serial_stream_write.cpp
@@ -8,7 +8,8 @@
 #include <fstream>
 #include <iostream>
 
-#define DEFAULT_SERIAL_PORT_1 "/dev/ttyUSB1"
+constexpr const char* const SERIAL_PORT_2 = "/dev/ttyUSB1" ;
+
 
 /**
  * @brief This example reads the contents of a file and writes the entire 
@@ -46,7 +47,7 @@ int main(int argc, char** argv)
     try
     {
         // Open the Serial Port at the desired hardware port.
-        serial_stream.Open(DEFAULT_SERIAL_PORT_1) ;
+        serial_stream.Open(SERIAL_PORT_2) ;
     }
     catch (const OpenFailed&)
     {

--- a/test/MultiThreadUnitTests.cpp
+++ b/test/MultiThreadUnitTests.cpp
@@ -226,11 +226,11 @@ MultiThreadUnitTests::testMultiThreadSerialStreamReadWrite()
     // Otherwise, one thread may flush the serial port I/O buffers *after* the
     // other thread has already sent data. 
     //
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
     serialStream1.SetBaudRate(BaudRate::BAUD_115200) ;
     serialStream1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE) ;
 
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
     serialStream2.SetBaudRate(BaudRate::BAUD_115200) ;
     serialStream2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE) ;
 
@@ -252,11 +252,11 @@ MultiThreadUnitTests::testMultiThreadSerialPortReadWrite()
     // Otherwise, one thread may flush the serial port I/O buffers *after* the
     // other thread has already sent data. 
     //
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
     serialPort1.SetBaudRate(BaudRate::BAUD_115200) ;
     serialPort1.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE) ;
 
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
     serialPort2.SetBaudRate(BaudRate::BAUD_115200) ;
     serialPort2.SetFlowControl(FlowControl::FLOW_CONTROL_HARDWARE) ;
 

--- a/test/SerialPortUnitTests.cpp
+++ b/test/SerialPortUnitTests.cpp
@@ -55,8 +55,8 @@ SerialPortUnitTests::~SerialPortUnitTests()
 void
 SerialPortUnitTests::testSerialPortConstructors()
 {
-    SerialPort serialPort3(TEST_SERIAL_PORT_1) ;
-    SerialPort serialPort4(TEST_SERIAL_PORT_2,
+    SerialPort serialPort3(SERIAL_PORT_1) ;
+    SerialPort serialPort4(SERIAL_PORT_2,
                            BaudRate::BAUD_9600,
                            CharacterSize::CHAR_SIZE_7,
                            FlowControl::FLOW_CONTROL_HARDWARE,
@@ -82,8 +82,8 @@ SerialPortUnitTests::testSerialPortConstructors()
 void
 SerialPortUnitTests::testSerialPortOpenClose()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -98,8 +98,8 @@ SerialPortUnitTests::testSerialPortOpenClose()
 
     try
     {
-        serialPort3.Open(TEST_SERIAL_PORT_1) ;
-        serialPort4.Open(TEST_SERIAL_PORT_2) ;
+        serialPort3.Open(SERIAL_PORT_1) ;
+        serialPort4.Open(SERIAL_PORT_2) ;
     }
     catch (...)
     {
@@ -118,8 +118,8 @@ SerialPortUnitTests::testSerialPortOpenClose()
 void
 SerialPortUnitTests::testSerialPortDrainWriteBuffer()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -155,8 +155,8 @@ SerialPortUnitTests::testSerialPortDrainWriteBuffer()
 void
 SerialPortUnitTests::testSerialPortFlushInputBuffer()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -197,8 +197,8 @@ SerialPortUnitTests::testSerialPortFlushInputBuffer()
 void
 SerialPortUnitTests::testSerialPortFlushOutputBuffer()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -230,8 +230,8 @@ SerialPortUnitTests::testSerialPortFlushOutputBuffer()
 void
 SerialPortUnitTests::testSerialPortFlushIOBuffers()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -276,8 +276,8 @@ SerialPortUnitTests::testSerialPortFlushIOBuffers()
 void
 SerialPortUnitTests::testSerialPortIsDataAvailableTest()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -326,8 +326,8 @@ SerialPortUnitTests::testSerialPortIsOpenTest()
     ASSERT_FALSE(serialPort1.IsOpen()) ;
     ASSERT_FALSE(serialPort2.IsOpen()) ;
 
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -342,8 +342,8 @@ SerialPortUnitTests::testSerialPortIsOpenTest()
 void
 SerialPortUnitTests::testSerialPortSetGetBaudRate()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -370,8 +370,8 @@ SerialPortUnitTests::testSerialPortSetGetBaudRate()
 void
 SerialPortUnitTests::testSerialPortSetGetCharacterSize()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -404,8 +404,8 @@ SerialPortUnitTests::testSerialPortSetGetCharacterSize()
 void
 SerialPortUnitTests::testSerialPortSetGetFlowControl()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -438,8 +438,8 @@ SerialPortUnitTests::testSerialPortSetGetFlowControl()
 void
 SerialPortUnitTests::testSerialPortSetGetParity()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -466,8 +466,8 @@ SerialPortUnitTests::testSerialPortSetGetParity()
 void
 SerialPortUnitTests::testSerialPortSetGetStopBits()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -494,7 +494,7 @@ SerialPortUnitTests::testSerialPortSetGetStopBits()
 void
 SerialPortUnitTests::testSerialPortSetGetVMin()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
     ASSERT_TRUE(serialPort1.IsOpen()) ;
 
     for (short i = 0; i < 5; i++)
@@ -511,7 +511,7 @@ SerialPortUnitTests::testSerialPortSetGetVMin()
 void
 SerialPortUnitTests::testSerialPortSetGetVTime()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
     ASSERT_TRUE(serialPort1.IsOpen()) ;
 
     for (short i = 0; i < 5; i++)
@@ -528,8 +528,8 @@ SerialPortUnitTests::testSerialPortSetGetVTime()
 void
 SerialPortUnitTests::testSerialPortSetGetDTR()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -574,8 +574,8 @@ SerialPortUnitTests::testSerialPortSetGetDTR()
 void
 SerialPortUnitTests::testSerialPortSetGetRTS()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -620,8 +620,8 @@ SerialPortUnitTests::testSerialPortSetGetRTS()
 void
 SerialPortUnitTests::testSerialPortSetRTSGetCTS()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -666,8 +666,8 @@ SerialPortUnitTests::testSerialPortSetRTSGetCTS()
 void
 SerialPortUnitTests::testSerialPortSetDTRGetDSR()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -712,8 +712,8 @@ SerialPortUnitTests::testSerialPortSetDTRGetDSR()
 void
 SerialPortUnitTests::testSerialPortGetFileDescriptor()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -734,8 +734,8 @@ SerialPortUnitTests::testSerialPortGetFileDescriptor()
 void
 SerialPortUnitTests::testSerialPortGetNumberOfBytesAvailable()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -785,8 +785,8 @@ SerialPortUnitTests::testSerialPortGetNumberOfBytesAvailable()
 void
 SerialPortUnitTests::testSerialPortGetAvailableSerialPorts()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -811,8 +811,8 @@ SerialPortUnitTests::testSerialPortGetAvailableSerialPorts()
 void
 SerialPortUnitTests::testSerialPortReadDataBufferWriteDataBuffer()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -889,8 +889,8 @@ SerialPortUnitTests::testSerialPortReadDataBufferWriteDataBuffer()
 void
 SerialPortUnitTests::testSerialPortReadStringWriteString()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -940,8 +940,8 @@ SerialPortUnitTests::testSerialPortReadStringWriteString()
 void
 SerialPortUnitTests::testSerialPortReadByteWriteByte()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
@@ -988,8 +988,8 @@ SerialPortUnitTests::testSerialPortReadByteWriteByte()
 void
 SerialPortUnitTests::testSerialPortReadLineWriteString()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
-    serialPort2.Open(TEST_SERIAL_PORT_2) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
+    serialPort2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;

--- a/test/SerialStreamUnitTests.cpp
+++ b/test/SerialStreamUnitTests.cpp
@@ -55,8 +55,8 @@ SerialStreamUnitTests::~SerialStreamUnitTests()
 void
 SerialStreamUnitTests::testSerialStreamConstructors()
 {
-    SerialStream serialStream3(TEST_SERIAL_PORT_1) ;
-    SerialStream serialStream4(TEST_SERIAL_PORT_2,
+    SerialStream serialStream3(SERIAL_PORT_1) ;
+    SerialStream serialStream4(SERIAL_PORT_2,
                                BaudRate::BAUD_9600,
                                CharacterSize::CHAR_SIZE_7,
                                FlowControl::FLOW_CONTROL_HARDWARE,
@@ -82,8 +82,8 @@ SerialStreamUnitTests::testSerialStreamConstructors()
 void
 SerialStreamUnitTests::testSerialStreamOpenClose()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -104,8 +104,8 @@ SerialStreamUnitTests::testSerialStreamOpenClose()
 
     try
     {
-        serialStream3.Open(TEST_SERIAL_PORT_1) ;
-        serialStream4.Open(TEST_SERIAL_PORT_2) ;
+        serialStream3.Open(SERIAL_PORT_1) ;
+        serialStream4.Open(SERIAL_PORT_2) ;
     }
     catch (...)
     {
@@ -124,8 +124,8 @@ SerialStreamUnitTests::testSerialStreamOpenClose()
 void
 SerialStreamUnitTests::testSerialStreamDrainWriteBuffer()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -158,8 +158,8 @@ SerialStreamUnitTests::testSerialStreamDrainWriteBuffer()
 void
 SerialStreamUnitTests::testSerialStreamFlushInputBuffer()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -200,8 +200,8 @@ SerialStreamUnitTests::testSerialStreamFlushInputBuffer()
 void
 SerialStreamUnitTests::testSerialStreamFlushOutputBuffer()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -233,8 +233,8 @@ SerialStreamUnitTests::testSerialStreamFlushOutputBuffer()
 void
 SerialStreamUnitTests::testSerialStreamFlushIOBuffers()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -279,8 +279,8 @@ SerialStreamUnitTests::testSerialStreamFlushIOBuffers()
 void
 SerialStreamUnitTests::testSerialStreamIsDataAvailableTest()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -329,8 +329,8 @@ SerialStreamUnitTests::testSerialStreamIsOpenTest()
     ASSERT_FALSE(serialStream1.IsOpen()) ;
     ASSERT_FALSE(serialStream2.IsOpen()) ;
 
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -345,8 +345,8 @@ SerialStreamUnitTests::testSerialStreamIsOpenTest()
 void
 SerialStreamUnitTests::testSerialStreamSetGetBaudRate()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -373,8 +373,8 @@ SerialStreamUnitTests::testSerialStreamSetGetBaudRate()
 void
 SerialStreamUnitTests::testSerialStreamSetGetCharacterSize()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -407,8 +407,8 @@ SerialStreamUnitTests::testSerialStreamSetGetCharacterSize()
 void
 SerialStreamUnitTests::testSerialStreamSetGetFlowControl()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -435,8 +435,8 @@ SerialStreamUnitTests::testSerialStreamSetGetFlowControl()
 void
 SerialStreamUnitTests::testSerialStreamSetGetParity()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -463,8 +463,8 @@ SerialStreamUnitTests::testSerialStreamSetGetParity()
 void
 SerialStreamUnitTests::testSerialStreamSetGetStopBits()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -491,8 +491,8 @@ SerialStreamUnitTests::testSerialStreamSetGetStopBits()
 void
 SerialStreamUnitTests::testSerialStreamSetGetVMin()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -522,8 +522,8 @@ SerialStreamUnitTests::testSerialStreamSetGetVMin()
 void
 SerialStreamUnitTests::testSerialStreamSetGetVTime()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -553,8 +553,8 @@ SerialStreamUnitTests::testSerialStreamSetGetVTime()
 void
 SerialStreamUnitTests::testSerialStreamSetGetDTR()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -599,8 +599,8 @@ SerialStreamUnitTests::testSerialStreamSetGetDTR()
 void
 SerialStreamUnitTests::testSerialStreamSetGetRTS()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -645,8 +645,8 @@ SerialStreamUnitTests::testSerialStreamSetGetRTS()
 void
 SerialStreamUnitTests::testSerialStreamSetRTSGetCTS()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -691,8 +691,8 @@ SerialStreamUnitTests::testSerialStreamSetRTSGetCTS()
 void
 SerialStreamUnitTests::testSerialStreamSetDTRGetDSR()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -737,8 +737,8 @@ SerialStreamUnitTests::testSerialStreamSetDTRGetDSR()
 void
 SerialStreamUnitTests::testSerialStreamGetFileDescriptor()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -759,8 +759,8 @@ SerialStreamUnitTests::testSerialStreamGetFileDescriptor()
 void
 SerialStreamUnitTests::testSerialStreamGetNumberOfBytesAvailable()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -807,8 +807,8 @@ SerialStreamUnitTests::testSerialStreamGetNumberOfBytesAvailable()
 void
 SerialStreamUnitTests::testSerialStreamGetAvailableSerialPorts()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -839,8 +839,8 @@ SerialStreamUnitTests::testSerialStreamGetAvailableSerialPorts()
 void
 SerialStreamUnitTests::testSerialStreamReadByteWriteByte()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -879,8 +879,8 @@ SerialStreamUnitTests::testSerialStreamReadByteWriteByte()
 void
 SerialStreamUnitTests::testSerialStreamGetLineWriteString()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
@@ -904,8 +904,8 @@ SerialStreamUnitTests::testSerialStreamGetLineWriteString()
 void
 SerialStreamUnitTests::testSerialStreamGetWriteByte()
 {
-    serialStream1.Open(TEST_SERIAL_PORT_1) ;
-    serialStream2.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_1) ;
+    serialStream2.Open(SERIAL_PORT_2) ;
 
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;

--- a/test/UnitTests.cpp
+++ b/test/UnitTests.cpp
@@ -77,10 +77,10 @@ UnitTests::getTimeInMicroSeconds()
 void
 UnitTests::testSerialStreamToSerialPortReadWrite()
 {
-    serialPort1.Open(TEST_SERIAL_PORT_1) ;
+    serialPort1.Open(SERIAL_PORT_1) ;
     ASSERT_TRUE(serialPort1.IsOpen()) ;
 
-    serialStream1.Open(TEST_SERIAL_PORT_2) ;
+    serialStream1.Open(SERIAL_PORT_2) ;
     ASSERT_TRUE(serialStream1.IsOpen()) ;
 
     const auto baud_rate = BaudRate::BAUD_115200 ;

--- a/test/UnitTests.h
+++ b/test/UnitTests.h
@@ -50,12 +50,12 @@ namespace LibSerial
     /**
      * @var Default Serial Port 1.
      */
-    constexpr const char* const TEST_SERIAL_PORT_1 = "/dev/ttyUSB0" ;
+    constexpr const char* const SERIAL_PORT_1 = "/dev/ttyUSB0" ;
 
     /**
      * @var Default Serial Port 2.
      */
-    constexpr const char* const TEST_SERIAL_PORT_2 = "/dev/ttyUSB1" ;
+    constexpr const char* const SERIAL_PORT_2 = "/dev/ttyUSB1" ;
 
     /**
      * @var The number of iterations to perform on each unit test.


### PR DESCRIPTION
Hi Crayzee Wulf,

This PR:
- Adds a few lines to the README.md to help future users with potential issues,
- Standardizes the declaration of 
```
constexpr const char* const SERIAL_PORT_1 = "/dev/ttyUSB0" ;
constexpr const char* const SERIAL_PORT_2 = "/dev/ttyUSB1" ;
```
in the `examples/` directory, and
- Renames `TEST_SERIAL_PORT_X` to `SERIAL_PORT_X` so that usage is uniform between unit tests and example code.

The PR is quite a few LOC, but the diff is pretty straightforward.

All unit tests and example executables pass hardware testing.

Let me know if you have any questions on this PR!

-Mark