### PR TITLE
Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+![Docker Stars](https://img.shields.io/docker/stars/crayzeewulf/libserial.svg)
+![Docker Pulls](https://img.shields.io/docker/pulls/crayzeewulf/libserial.svg)
+![Docker Automated](https://img.shields.io/docker/automated/crayzeewulf/libserial.svg)
+![Docker Build](https://img.shields.io/docker/build/crayzeewulf/libserial.svg)
+
 # Libserial
 
 ----

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![Docker Stars](https://img.shields.io/docker/stars/crayzeewulf/libserial.svg)
-![Docker Pulls](https://img.shields.io/docker/pulls/crayzeewulf/libserial.svg)
-![Docker Automated](https://img.shields.io/docker/automated/crayzeewulf/libserial.svg)
-![Docker Build](https://img.shields.io/docker/build/crayzeewulf/libserial.svg)
+[![Docker Stars](https://img.shields.io/docker/stars/crayzeewulf/libserial.svg)](https://cloud.docker.com/repository/docker/crayzeewulf/libserial/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/crayzeewulf/libserial.svg)](https://cloud.docker.com/repository/docker/crayzeewulf/libserial/)
+[![Docker Automated](https://img.shields.io/docker/automated/crayzeewulf/libserial.svg)](https://cloud.docker.com/repository/docker/crayzeewulf/libserial/)
+[![Docker Build](https://img.shields.io/docker/build/crayzeewulf/libserial.svg)](https://cloud.docker.com/repository/docker/crayzeewulf/libserial/)
 
 # Libserial
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-[![Docker Stars](https://img.shields.io/docker/stars/crayzeewulf/libserial.svg)](https://hub.docker.com/r/crayzeewulf/libserial)
-[![Docker Pulls](https://img.shields.io/docker/pulls/crayzeewulf/libserial.svg)](https://hub.docker.com/r/crayzeewulf/libserial)
-[![Docker Automated](https://img.shields.io/docker/automated/crayzeewulf/libserial.svg)](https://hub.docker.com/r/crayzeewulf/libserial)
-[![Docker Build](https://img.shields.io/docker/build/crayzeewulf/libserial.svg)](https://hub.docker.com/r/crayzeewulf/libserial)
-
 # Libserial
 
 ----

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Docker Stars](https://img.shields.io/docker/stars/crayzeewulf/libserial.svg)](https://cloud.docker.com/repository/docker/crayzeewulf/libserial/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/crayzeewulf/libserial.svg)](https://cloud.docker.com/repository/docker/crayzeewulf/libserial/)
-[![Docker Automated](https://img.shields.io/docker/automated/crayzeewulf/libserial.svg)](https://cloud.docker.com/repository/docker/crayzeewulf/libserial/)
-[![Docker Build](https://img.shields.io/docker/build/crayzeewulf/libserial.svg)](https://cloud.docker.com/repository/docker/crayzeewulf/libserial/)
+[![Docker Stars](https://img.shields.io/docker/stars/crayzeewulf/libserial.svg)](https://hub.docker.com/r/crayzeewulf/libserial)
+[![Docker Pulls](https://img.shields.io/docker/pulls/crayzeewulf/libserial.svg)](https://hub.docker.com/r/crayzeewulf/libserial)
+[![Docker Automated](https://img.shields.io/docker/automated/crayzeewulf/libserial.svg)](https://hub.docker.com/r/crayzeewulf/libserial)
+[![Docker Build](https://img.shields.io/docker/build/crayzeewulf/libserial.svg)](https://hub.docker.com/r/crayzeewulf/libserial)
 
 # Libserial
 

--- a/dockerfiles/centos/7/Dockerfile
+++ b/dockerfiles/centos/7/Dockerfile
@@ -1,3 +1,9 @@
+#
+# Run the following command from top-level folder of libserial source code
+# to build the libserial image for Ubuntu 18.04:
+#
+# docker build -t libserial:centos-7 -f dockerfiles/centos/7/Dockerfile .
+#
 # ------------------------------------------------------------------------------
 # base
 # ------------------------------------------------------------------------------

--- a/dockerfiles/centos/7/Dockerfile
+++ b/dockerfiles/centos/7/Dockerfile
@@ -1,6 +1,6 @@
 #
 # Run the following command from top-level folder of libserial source code
-# to build the libserial image for Ubuntu 18.04:
+# to build the libserial image for CentOS-7:
 #
 # docker build -t libserial:centos-7 -f dockerfiles/centos/7/Dockerfile .
 #

--- a/dockerfiles/centos/7/Dockerfile
+++ b/dockerfiles/centos/7/Dockerfile
@@ -1,0 +1,37 @@
+# ------------------------------------------------------------------------------
+# base
+# ------------------------------------------------------------------------------
+FROM centos:7 AS base
+
+RUN yum install -y centos-release-scl \
+    && yum install -y devtoolset-7-gcc-c++ \
+    && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && yum install -y \
+       boost-devel \
+       cmake3 \
+       doxygen \
+       graphviz \
+       make \
+       python-devel 
+
+# ------------------------------------------------------------------------------
+# build
+# ------------------------------------------------------------------------------
+FROM base AS build
+
+ENV CC /opt/rh/devtoolset-7/root/bin/gcc
+ENV CXX /opt/rh/devtoolset-7/root/bin/g++
+COPY . /usr/src/libserial
+RUN cd /usr/src/libserial \
+    && rm -rf build \
+    && mkdir -p build \
+    && cd build \
+    && cmake3 .. \
+    && make -j$(nproc) \
+    && make install
+
+# ------------------------------------------------------------------------------
+# release
+# ------------------------------------------------------------------------------
+FROM centos:7 AS release
+COPY --from=build /usr/local /usr/local

--- a/dockerfiles/debian/buster/Dockerfile
+++ b/dockerfiles/debian/buster/Dockerfile
@@ -1,6 +1,6 @@
 #
 # Run the following command from top-level folder of libserial source code
-# to build the libserial image for Ubuntu 18.04:
+# to build the libserial image for Debian-buster:
 #
 # docker build -t libserial:debian-buster -f dockerfiles/debian/buster/Dockerfile .
 #

--- a/dockerfiles/debian/buster/Dockerfile
+++ b/dockerfiles/debian/buster/Dockerfile
@@ -1,3 +1,9 @@
+#
+# Run the following command from top-level folder of libserial source code
+# to build the libserial image for Ubuntu 18.04:
+#
+# docker build -t libserial:debian-buster -f dockerfiles/debian/buster/Dockerfile .
+#
 # ------------------------------------------------------------------------------
 # base
 # ------------------------------------------------------------------------------

--- a/dockerfiles/debian/buster/Dockerfile
+++ b/dockerfiles/debian/buster/Dockerfile
@@ -1,0 +1,40 @@
+# ------------------------------------------------------------------------------
+# base
+# ------------------------------------------------------------------------------
+FROM debian:buster AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -yq update && apt-get install -yq --no-install-recommends \
+        build-essential \
+        cmake \
+        coreutils \
+        doxygen \
+        g++ \
+        graphviz \
+        libboost-test-dev \
+        libgtest-dev \
+        libpython-dev \
+    && apt-get autoremove -y \
+    && apt-get clean -y
+
+
+# ------------------------------------------------------------------------------
+# build
+# ------------------------------------------------------------------------------
+FROM base AS build
+
+COPY . /usr/src/libserial
+RUN cd /usr/src/libserial \
+    && rm -rf build \
+    && mkdir -p build \
+    && cd build \
+    && cmake .. \
+    && make -j$(nproc) \
+    && make install
+
+# ------------------------------------------------------------------------------
+# release
+# ------------------------------------------------------------------------------
+
+FROM debian:buster AS release
+COPY --from=build /usr/local /usr/local

--- a/dockerfiles/ubuntu/18.04/Dockerfile
+++ b/dockerfiles/ubuntu/18.04/Dockerfile
@@ -1,0 +1,41 @@
+# ------------------------------------------------------------------------------
+# base
+# ------------------------------------------------------------------------------
+FROM ubuntu:18.04 AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -yq update && apt-get install -yq --no-install-recommends \
+        build-essential \
+        cmake \
+        coreutils \
+        doxygen \
+        g++ \
+        git \
+        graphviz \
+        libboost-test-dev \
+        libgtest-dev \
+        libpython-dev \
+    && apt-get autoremove -y \
+    && apt-get clean -y
+
+
+# ------------------------------------------------------------------------------
+# build
+# ------------------------------------------------------------------------------
+FROM base AS build
+
+COPY . /usr/src/libserial
+RUN cd /usr/src/libserial \
+    && rm -rf build \
+    && mkdir -p build \
+    && cd build \
+    && cmake .. \
+    && make -j$(nproc) \
+    && make install
+
+# ------------------------------------------------------------------------------
+# release
+# ------------------------------------------------------------------------------
+
+FROM ubuntu:18.04 AS release
+COPY --from=build /usr/local /usr/local

--- a/dockerfiles/ubuntu/18.04/Dockerfile
+++ b/dockerfiles/ubuntu/18.04/Dockerfile
@@ -1,3 +1,9 @@
+#
+# Run the following command from top-level folder of libserial source code
+# to build the libserial image for Ubuntu 18.04:
+#
+# docker build -t libserial:ubuntu-18.04 -f dockerfiles/ubuntu/18.04/Dockerfile .
+#
 # ------------------------------------------------------------------------------
 # base
 # ------------------------------------------------------------------------------

--- a/dockerfiles/ubuntu/18.04/Dockerfile
+++ b/dockerfiles/ubuntu/18.04/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get -yq update && apt-get install -yq --no-install-recommends \
         coreutils \
         doxygen \
         g++ \
-        git \
         graphviz \
         libboost-test-dev \
         libgtest-dev \


### PR DESCRIPTION
Added docker files for testing libserial builds on various Linux distributions. The following Linux distributions are included:

* CentOS 7
* Debian Buster
* Ubuntu 18.04

Support for additional distributions will be added in the future.