### PR TITLE
Fixes issue #137

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.8)
+#
+# Minimum version is 3.5 (this supports Ubuntu 16.04 and later, for example)
+#
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 #
 # Project version numbering using semantic versioning. See:
@@ -21,6 +24,12 @@ option(LIBSERIAL_BUILD_DOCS "Build the Doxygen docs" ON)
 #
 OPTION(INSTALL_STATIC "Install static library." ON)
 OPTION(INSTALL_SHARED "Install shared object library." ON)
+
+#
+# LibSerial requies a C++ compiler that supports at least C++14 standard
+#
+SET(CMAKE_CXX_STANDARD 14)
+SET(CMAKE_STANDARD_REQUIRES ON)
 
 INCLUDE(ExternalProject)
 

--- a/dockerfiles/debian/buster/Dockerfile
+++ b/dockerfiles/debian/buster/Dockerfile
@@ -36,7 +36,8 @@ RUN cd /usr/src/libserial \
     && cd build \
     && cmake .. \
     && make -j$(nproc) \
-    && make install
+    && make install \
+    && chown -R root:root /usr/local
 
 # ------------------------------------------------------------------------------
 # release

--- a/dockerfiles/ubuntu/16.04/Dockerfile
+++ b/dockerfiles/ubuntu/16.04/Dockerfile
@@ -1,0 +1,47 @@
+#
+# Run the following command from top-level folder of libserial source code
+# to build the libserial image for Ubuntu 16.04:
+#
+# docker build -t libserial:ubuntu-16.04 -f dockerfiles/ubuntu/16.04/Dockerfile .
+#
+# ------------------------------------------------------------------------------
+# base
+# ------------------------------------------------------------------------------
+FROM ubuntu:16.04 AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get -yq update && apt-get install -yq --no-install-recommends \
+        build-essential \
+        cmake \
+        coreutils \
+        doxygen \
+        g++ \
+        graphviz \
+        libboost-test-dev \
+        libgtest-dev \
+        libpython-dev \
+    && apt-get autoremove -y \
+    && apt-get clean -y
+
+
+# ------------------------------------------------------------------------------
+# build
+# ------------------------------------------------------------------------------
+FROM base AS build
+
+COPY . /usr/src/libserial
+RUN cd /usr/src/libserial \
+    && rm -rf build \
+    && mkdir -p build \
+    && cd build \
+    && cmake .. \
+    && make -j$(nproc) \
+    && make install \
+    && chown -R root:root /usr/local
+
+# ------------------------------------------------------------------------------
+# release
+# ------------------------------------------------------------------------------
+
+FROM ubuntu:16.04 AS release
+COPY --from=build /usr/local /usr/local

--- a/dockerfiles/ubuntu/18.04/Dockerfile
+++ b/dockerfiles/ubuntu/18.04/Dockerfile
@@ -36,7 +36,8 @@ RUN cd /usr/src/libserial \
     && cd build \
     && cmake .. \
     && make -j$(nproc) \
-    && make install
+    && make install \
+    && chown -R root:root /usr/local
 
 # ------------------------------------------------------------------------------
 # release


### PR DESCRIPTION
Fixes to build on Ubuntu 16.04 to address issue #137
    
- Dropped minimum required CMake version to 3.5.
- Added checks to make sure that we are using C++ compiler with C++14
  support enabled.
