### PR TITLE
Augment SerialPortUnitTest and SerialStreamUnitTest tests to quiet compiler warnings.

### DIFF
--- a/test/SerialPortUnitTests.cpp
+++ b/test/SerialPortUnitTests.cpp
@@ -791,14 +791,11 @@ SerialPortUnitTests::testSerialPortGetAvailableSerialPorts()
     ASSERT_TRUE(serialPort1.IsOpen()) ;
     ASSERT_TRUE(serialPort2.IsOpen()) ;
 
-    const auto serialPorts1 = serialPort1.GetAvailableSerialPorts() ;
-    const auto serialPorts2 = serialPort2.GetAvailableSerialPorts() ;
+    const auto portCount1 = serialPort1.GetAvailableSerialPorts() ;
+    const auto portCount2 = serialPort2.GetAvailableSerialPorts() ;
 
-    const auto portCount1 = serialPorts1.size() ;
-    const auto portCount2 = serialPorts2.size() ;
-
-    ASSERT_GE(portCount1, 2) ;
-    ASSERT_GE(portCount2, 2) ;
+    ASSERT_GE(portCount1.size(), 2UL) ;
+    ASSERT_GE(portCount2.size(), 2UL) ;
     ASSERT_EQ(portCount1, portCount2) ;
 
     serialPort1.Close() ;

--- a/test/SerialStreamUnitTests.cpp
+++ b/test/SerialStreamUnitTests.cpp
@@ -813,20 +813,11 @@ SerialStreamUnitTests::testSerialStreamGetAvailableSerialPorts()
     ASSERT_TRUE(serialStream1.IsOpen()) ;
     ASSERT_TRUE(serialStream2.IsOpen()) ;
 
-    std::vector<std::string> serialPorts1;
-    std::vector<std::string> serialPorts2;
+    const auto portCount1 = serialStream1.GetAvailableSerialPorts() ;
+    const auto portCount2 = serialStream2.GetAvailableSerialPorts() ;
 
-    serialPorts1.clear() ;
-    serialPorts2.clear() ;
-
-    serialPorts1 = serialStream1.GetAvailableSerialPorts() ;
-    serialPorts2 = serialStream2.GetAvailableSerialPorts() ;
-
-    const auto portCount1 = serialPorts1.size() ;
-    const auto portCount2 = serialPorts2.size() ;
-
-    ASSERT_GE(portCount1, 2) ;
-    ASSERT_GE(portCount2, 2) ;
+    ASSERT_GE(portCount1.size(), 2UL) ;
+    ASSERT_GE(portCount2.size(), 2UL) ;
     ASSERT_EQ(portCount1, portCount2) ;
 
     serialStream1.Close() ;


### PR DESCRIPTION
Hi @crayzeewulf ,

This PR quiets a compiler warning in the unit test framework. Hardware unit tests are passing with this PR and the warning is silenced.

Please let me know if you have any questions on this PR!

-Mark