### PR TITLE
Modify exception types to better match the intent in a few SerialPort class methods.

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -1371,7 +1371,7 @@ namespace LibSerial
         if (tcflush(this->mFileDescriptor,
                     TCIOFLUSH) < 0)
         {
-            throw OpenFailed(std::strerror(errno)) ;
+            throw std::runtime_error(std::strerror(errno)) ;
         }
 
         // Get the current serial port settings.
@@ -2088,7 +2088,7 @@ namespace LibSerial
                       TCSANOW,
                       &port_settings) < 0)
         {
-            throw OpenFailed(std::strerror(errno)) ;
+            throw std::runtime_error(std::strerror(errno)) ;
         }
     }
 
@@ -2120,7 +2120,7 @@ namespace LibSerial
                       TCSANOW,
                       &port_settings) < 0)
         {
-            throw OpenFailed(std::strerror(errno)) ;
+            throw std::runtime_error(std::strerror(errno)) ;
         }
     }
 
@@ -2151,7 +2151,7 @@ namespace LibSerial
                       TCSANOW,
                       &port_settings) < 0)
         {
-            throw OpenFailed(std::strerror(errno)) ;
+            throw std::runtime_error(std::strerror(errno)) ;
         }
     }
 
@@ -2183,7 +2183,7 @@ namespace LibSerial
                       TCSANOW,
                       &port_settings) < 0)
         {
-            throw OpenFailed(std::strerror(errno)) ;
+            throw std::runtime_error(std::strerror(errno)) ;
         }
     }
 
@@ -2214,7 +2214,7 @@ namespace LibSerial
                       TCSANOW,
                       &port_settings) < 0)
         {
-            throw OpenFailed(std::strerror(errno)) ;
+            throw std::runtime_error(std::strerror(errno)) ;
         }
     }
 


### PR DESCRIPTION
Hi @crayzeewulf , 

This PR changes the exception types thrown in a few methods in the SerialPort class that I **think** were copy paste errors that I likely made previously.

If these exception types are correct please let me know and we can close this PR to leave them as-is.

EDIT: Hardware unit tests all pass with this PR.

Thanks!

-Mark