### PR TITLE
Apply linux specific #ifdef __linux__ encapsulation of the GetAvailableSerialPort() methods.

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -285,12 +285,15 @@ namespace LibSerial
          */
         int GetNumberOfBytesAvailable() ;
 
+#ifdef __linux__
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port.
          */
         std::vector<std::string> GetAvailableSerialPorts() const ;
+#endif
+
         /**
          * @brief Reads the specified number of bytes from the serial port.
          *        The method will timeout if no data is received in the
@@ -679,11 +682,13 @@ namespace LibSerial
         return mImpl->GetNumberOfBytesAvailable() ;
     }
 
+#ifdef __linux__
     std::vector<std::string>
     SerialPort::GetAvailableSerialPorts() const
     {
         return mImpl->GetAvailableSerialPorts() ;
     }
+#endif
 
     void
     SerialPort::Read(DataBuffer& dataBuffer,
@@ -1858,6 +1863,7 @@ namespace LibSerial
         return number_of_bytes_available ;
     }
 
+#ifdef __linux__
     inline
     std::vector<std::string>
     SerialPort::Implementation::GetAvailableSerialPorts() const
@@ -1902,6 +1908,7 @@ namespace LibSerial
 
         return serial_port_names ;
     }
+#endif
 
     inline
     void

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -283,12 +283,14 @@ namespace LibSerial
          */
         int GetNumberOfBytesAvailable() ;
 
+#ifdef __linux__
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port.
          */
         std::vector<std::string> GetAvailableSerialPorts() const ;
+#endif
 
         /**
          * @brief Writes up to n characters from the character sequence at
@@ -590,11 +592,13 @@ namespace LibSerial
         return mImpl->GetNumberOfBytesAvailable() ;
     }
 
+#ifdef __linux__
     std::vector<std::string>
     SerialStreamBuf::GetAvailableSerialPorts() const
     {
         return mImpl->GetAvailableSerialPorts() ;
     }
+#endif
 
     std::streambuf*
     SerialStreamBuf::setbuf(char_type* character, std::streamsize numberOfBytes)
@@ -924,12 +928,14 @@ namespace LibSerial
         return mSerialPort.GetNumberOfBytesAvailable() ;
     }
 
+#ifdef __linux__
     inline
     std::vector<std::string>
     SerialStreamBuf::Implementation::GetAvailableSerialPorts() const
     {
         return mSerialPort.GetAvailableSerialPorts() ;
     }
+#endif
 
     inline
     std::streamsize

--- a/src/libserial/SerialPort.h
+++ b/src/libserial/SerialPort.h
@@ -297,12 +297,14 @@ namespace LibSerial
          */
         int GetNumberOfBytesAvailable() ;
 
+#ifdef __linux__
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port.
          */
         std::vector<std::string> GetAvailableSerialPorts() const ;
+#endif
 
         /**
          * @brief Reads the specified number of bytes from the serial port.

--- a/src/libserial/SerialStreamBuf.h
+++ b/src/libserial/SerialStreamBuf.h
@@ -300,12 +300,14 @@ namespace LibSerial
          */
         int GetNumberOfBytesAvailable() ;
 
+#ifdef __linux__
         /**
          * @brief Gets a list of available serial ports.
          * @return Returns a std::vector of std::strings with the name of
          *         each available serial port. 
          */
         std::vector<std::string> GetAvailableSerialPorts() const ;
+#endif
 
     protected:
 

--- a/test/SerialPortUnitTests.cpp
+++ b/test/SerialPortUnitTests.cpp
@@ -782,6 +782,7 @@ SerialPortUnitTests::testSerialPortGetNumberOfBytesAvailable()
     ASSERT_FALSE(serialPort2.IsOpen()) ;
 }
 
+#ifdef __linux__
 void
 SerialPortUnitTests::testSerialPortGetAvailableSerialPorts()
 {
@@ -804,6 +805,7 @@ SerialPortUnitTests::testSerialPortGetAvailableSerialPorts()
     ASSERT_FALSE(serialPort1.IsOpen()) ;
     ASSERT_FALSE(serialPort2.IsOpen()) ;
 }
+#endif
 
 void
 SerialPortUnitTests::testSerialPortReadDataBufferWriteDataBuffer()
@@ -1234,6 +1236,7 @@ TEST_F(SerialPortUnitTests, testSerialPortGetNumberOfBytesAvailable)
     }
 }
 
+#ifdef __linux__
 TEST_F(SerialPortUnitTests, testSerialPortGetAvailableSerialPorts)
 {
     SCOPED_TRACE("Serial Port GetAvailableSerialPorts() Test") ;
@@ -1243,6 +1246,7 @@ TEST_F(SerialPortUnitTests, testSerialPortGetAvailableSerialPorts)
         testSerialPortGetAvailableSerialPorts() ;
     }
 }
+#endif
 
 TEST_F(SerialPortUnitTests, testSerialPortReadDataBufferWriteDataBuffer)
 {

--- a/test/SerialPortUnitTests.h
+++ b/test/SerialPortUnitTests.h
@@ -166,10 +166,12 @@ namespace LibSerial
          */
         void testSerialPortGetNumberOfBytesAvailable() ;
 
+#ifdef __linux__
         /**
          * @brief Tests for correct functionality of the GetAvailableSerialPorts() method.
          */
         void testSerialPortGetAvailableSerialPorts() ;
+#endif
 
         /**
          * @brief Tests for correct functionality of the ReadDataBuffer() and WriteDataBuffer() methods.

--- a/test/SerialStreamUnitTests.cpp
+++ b/test/SerialStreamUnitTests.cpp
@@ -804,6 +804,7 @@ SerialStreamUnitTests::testSerialStreamGetNumberOfBytesAvailable()
     ASSERT_FALSE(serialStream2.IsOpen()) ;
 }
 
+#ifdef __linux__
 void
 SerialStreamUnitTests::testSerialStreamGetAvailableSerialPorts()
 {
@@ -826,6 +827,7 @@ SerialStreamUnitTests::testSerialStreamGetAvailableSerialPorts()
     ASSERT_FALSE(serialStream1.IsOpen()) ;
     ASSERT_FALSE(serialStream2.IsOpen()) ;
 }
+#endif
 
 void
 SerialStreamUnitTests::testSerialStreamReadByteWriteByte()
@@ -1143,6 +1145,7 @@ TEST_F(SerialStreamUnitTests, testSerialStreamGetNumberOfBytesAvailable)
     }
 }
 
+#ifdef __linux__
 TEST_F(SerialStreamUnitTests, testSerialStreamGetAvailableSerialPorts)
 {
     SCOPED_TRACE("Serial Stream GetAvailableSerialPorts() Test") ;
@@ -1152,6 +1155,7 @@ TEST_F(SerialStreamUnitTests, testSerialStreamGetAvailableSerialPorts)
         testSerialStreamGetAvailableSerialPorts() ;
     }
 }
+#endif
 
 TEST_F(SerialStreamUnitTests, testSerialStreamReadByteWriteByte)
 {

--- a/test/SerialStreamUnitTests.h
+++ b/test/SerialStreamUnitTests.h
@@ -167,10 +167,12 @@ namespace LibSerial
          */
         void testSerialStreamGetNumberOfBytesAvailable() ;
 
+#ifdef __linux__
         /**
          * @brief Tests for correct functionality of the GetAvailableSerialPorts() method.
          */
         void testSerialStreamGetAvailableSerialPorts() ;
+#endif
 
         /**
          * @brief Tests for correct functionality of the ReadByte() and WriteByte() methods.


### PR DESCRIPTION
Hi Crayzee Wulf,

This PR attempts to address compilation on for other POSIX users for at least one known problem area. If there is a better way to handle this that you have identified just let me know! 

@79rpm , I *think this PR will take care of issue #143.  Would you be willing to try this out and let us know if it allows you to build the library?  If it works we can accept this PR and close out the issue.

Thanks!

-Mark

**UPDATED:** Hardware unit tests passing.