### PR TITLE
Add python3-sphinx-rtd-theme to the README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Debian/Ubuntu users:
 sudo apt update
 sudo apt install g++ git autogen autoconf build-essential cmake graphviz \
                  libboost-dev libboost-test-dev libgtest-dev libtool \
-                 python-sip-dev doxygen python-sphinx pkg-config
+                 python-sip-dev doxygen python-sphinx pkg-config \
+                 python3-sphinx-rtd-theme
 ```
 
 


### PR DESCRIPTION
Hi @crayzeewulf , this PR adds python3-sphinx-rtd-theme to the README.md file to help close out #139.

Let me know if you think this is not needed, (we can just close this out if that's the case)!

-Mark