### PR TITLE
Add const specifiers to method arguments that were missing.

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -216,7 +216,7 @@ namespace LibSerial
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(short vmin) ;
+        void SetVMin(const short vmin) ;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -229,7 +229,7 @@ namespace LibSerial
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          */
-        void SetVTime(short vtime) ;
+        void SetVTime(const short vtime) ;
 
         /**
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
@@ -241,7 +241,7 @@ namespace LibSerial
          * @brief Sets the serial port DTR line status.
          * @param dtrState The state to set the DTR line
          */
-        void SetDTR(bool dtrState) ;
+        void SetDTR(const bool dtrState) ;
 
         /**
          * @brief Gets the serial port DTR line status.
@@ -253,7 +253,7 @@ namespace LibSerial
          * @brief Sets the serial port RTS line status.
          * @param rtsState The state to set the RTS line
          */
-        void SetRTS(bool rtsState) ;
+        void SetRTS(const bool rtsState) ;
 
         /**
          * @brief Gets the serial port RTS line status.

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -214,7 +214,7 @@ namespace LibSerial
          * @brief Sets the minimum number of characters for non-canonical reads.
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(short vmin) ;
+        void SetVMin(const short vmin) ;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -227,7 +227,7 @@ namespace LibSerial
          * @brief Sets character buffer timeout for non-canonical reads in deciseconds.
          * @param vtime The timeout value in deciseconds to be set.
          */
-        void SetVTime(short vtime) ;
+        void SetVTime(const short vtime) ;
 
         /**
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
@@ -239,7 +239,7 @@ namespace LibSerial
          * @brief Sets the serial port DTR line status.
          * @param dtrState The state to set the DTR line
          */
-        void SetDTR(bool dtrState) ;
+        void SetDTR(const bool dtrState) ;
 
         /**
          * @brief Gets the serial port DTR line status.
@@ -251,7 +251,7 @@ namespace LibSerial
          * @brief Sets the serial port RTS line status.
          * @param rtsState The state to set the RTS line
          */
-        void SetRTS(bool rtsState) ;
+        void SetRTS(const bool rtsState) ;
 
         /**
          * @brief Gets the serial port RTS line status.

--- a/src/libserial/SerialPort.h
+++ b/src/libserial/SerialPort.h
@@ -224,7 +224,7 @@ namespace LibSerial
          * @note See VMIN in man termios(3).
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(short vmin) ;
+        void SetVMin(const short vmin) ;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -239,7 +239,7 @@ namespace LibSerial
          * @param vtime The timeout value in deciseconds to be set.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds.
          */
-        void SetVTime(short vtime) ;
+        void SetVTime(const short vtime) ;
 
         /**
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
@@ -252,7 +252,7 @@ namespace LibSerial
          * @param dtrState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetDTR(bool dtrState = true) ;
+        void SetDTR(const bool dtrState = true) ;
 
         /**
          * @brief Gets the status of the DTR line.
@@ -265,7 +265,7 @@ namespace LibSerial
          * @param rtsState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetRTS(bool rtsState = true) ;
+        void SetRTS(const bool rtsState = true) ;
 
         /**
          * @brief Get the status of the RTS line.

--- a/src/libserial/SerialStream.h
+++ b/src/libserial/SerialStream.h
@@ -247,7 +247,7 @@ namespace LibSerial
          * @note See VMIN in man termios(3).
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(short vmin) ;
+        void SetVMin(const short vmin) ;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -262,7 +262,7 @@ namespace LibSerial
          * @param vtime The timeout value in deciseconds to be set.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds.
          */
-        void SetVTime(short vtime) ;
+        void SetVTime(const short vtime) ;
 
         /**
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
@@ -275,7 +275,7 @@ namespace LibSerial
          * @param dtrState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetDTR(bool dtrState = true) ;
+        void SetDTR(const bool dtrState = true) ;
 
         /**
          * @brief Gets the status of the DTR line.
@@ -288,7 +288,7 @@ namespace LibSerial
          * @param rtsState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetRTS(bool rtsState = true) ;
+        void SetRTS(const bool rtsState = true) ;
 
         /**
          * @brief Get the status of the RTS line.

--- a/src/libserial/SerialStreamBuf.h
+++ b/src/libserial/SerialStreamBuf.h
@@ -227,7 +227,7 @@ namespace LibSerial
          * @note See VMIN in man termios(3).
          * @param vmin the number of minimum characters to be set.
          */
-        void SetVMin(short vmin) ;
+        void SetVMin(const short vmin) ;
 
         /**
          * @brief Gets the VMIN value for the device, which represents the
@@ -242,7 +242,7 @@ namespace LibSerial
          * @param vtime The timeout value in deciseconds to be set.
          * @return Returns the character buffer timeout for non-canonical reads in deciseconds.
          */
-        void SetVTime(short vtime) ;
+        void SetVTime(const short vtime) ;
 
         /** 
          * @brief Gets the current timeout value for non-canonical reads in deciseconds.
@@ -255,7 +255,7 @@ namespace LibSerial
          * @param dtrState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetDTR(bool dtrState = true) ;
+        void SetDTR(const bool dtrState = true) ;
 
         /**
          * @brief Gets the status of the DTR line.
@@ -268,7 +268,7 @@ namespace LibSerial
          * @param rtsState The line voltage state to be set,
          *        (true = high, false = low).
          */
-        void SetRTS(bool rtsState = true) ;
+        void SetRTS(const bool rtsState = true) ;
 
         /**
          * @brief Get the status of the RTS line.


### PR DESCRIPTION
Hi @crayzeewulf , in reviewing code tonight I noticed that a handful of methods were lacking const specifiers where they could be added.  I don't recall if this was intentional or simply an oversight.

This PR adds const specifiers to method arguments that can allow the addition.  Please go ahead and close this PR if they were omitted previously by design!

Thanks!

-Mark

EDIT: All unit tests are passing with this PR.  Please let me know if you'd like to see anything done differently!