### PR TITLE
Add additional linux specific encapsulation.

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -37,11 +37,14 @@
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
-#include <linux/serial.h>
 #include <sstream>
 #include <sys/ioctl.h>
 #include <type_traits>
 #include <unistd.h>
+
+#ifdef __linux__
+#include <linux/serial.h>
+#endif
 
 namespace LibSerial
 {
@@ -2106,7 +2109,9 @@ namespace LibSerial
 
         // @NOTE - termios.c_line is not a standard element of the termios
         // structure, (as per the Single Unix Specification 3).
-        port_settings.c_line = '\0' ;
+        #ifdef __linux__
+          port_settings.c_line = '\0' ;
+        #endif
 
         // Apply the modified settings.
         if (tcsetattr(this->mFileDescriptor,

--- a/src/SerialStream.cpp
+++ b/src/SerialStream.cpp
@@ -906,6 +906,7 @@ namespace LibSerial
         throw ;
     }
 
+#ifdef __linux__
     std::vector<std::string>
     SerialStream::GetAvailableSerialPorts()
     try
@@ -932,4 +933,5 @@ namespace LibSerial
         setstate(std::ios_base::failbit) ;
         throw ;
     }
+#endif
 } // namespace LibSerial

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -37,7 +37,6 @@
 #include <cassert>
 #include <cstring>
 #include <fcntl.h>
-#include <linux/serial.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Hi @crayzeewulf , 

As tracked in #184, @thewoz reports that this fixes his issue in macosX.

I'd prefer to find an alternative `ifdef` encapsulation limited to the `serial_struct` usage in the `SerialPort::GetAvailableSerialPorts()` function to allow macos compatibility within that function, but for now, hopefully this is at least a quick review and easy.

Let me know your thoughts!

-Mark 