### PR TITLE
Add missing cstdint header for uint8_t type

### DIFF
--- a/src/libserial/SerialPortConstants.h
+++ b/src/libserial/SerialPortConstants.h
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
This fixes compiler error 
```
In file included from /home/jussi/GIT/libserial/src/libserial/SerialPort.h:36,
                 from /home/jussi/GIT/libserial/src/SerialPort.cpp:34:
/home/jussi/GIT/libserial/src/libserial/SerialPortConstants.h:94:37: error: 'uint8_t' was not declared in this scope
   94 |     using DataBuffer =  std::vector<uint8_t> ;
      |                                     ^~~~~~~
compilation terminated due to -Wfatal-errors.

```
when compiling on gcc from Arch's official repos

```
[jussi@mustikki libserial.build]$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/13.1.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,objc,obj-c++ --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 13.1.1 20230429 (GCC) 
```