### PR TITLE
Release exclusive access to serial port on close

### DIFF
--- a/src/SerialStream.cpp
+++ b/src/SerialStream.cpp
@@ -46,10 +46,11 @@ namespace LibSerial
                                const CharacterSize& characterSize,
                                const FlowControl&   flowControlType,
                                const Parity&        parityType,
-                               const StopBits&      stopBits) : 
+                               const StopBits&      stopBits,
+                               bool                 exclusive) :
         std::iostream(nullptr)
     {
-        this->Open(fileName) ;  // NOLINT (fuchsia-default-arguments)
+        this->Open(fileName, std::ios_base::in | std::ios_base::out, exclusive) ;  // NOLINT (fuchsia-default-arguments)
         this->SetBaudRate(baudRate) ;
         this->SetCharacterSize(characterSize) ;
         this->SetFlowControl(flowControlType) ;
@@ -81,7 +82,8 @@ namespace LibSerial
 
     void
     SerialStream::Open(const std::string& fileName,
-                       const std::ios_base::openmode& openMode)
+                       const std::ios_base::openmode& openMode,
+                       bool exclusive)
     try
     {
         // Create a new SerialStreamBuf if one does not exist. 
@@ -93,7 +95,7 @@ namespace LibSerial
         }
 
         // Open the serial port. 
-        mIOBuffer->Open(fileName, openMode) ;
+        mIOBuffer->Open(fileName, openMode, exclusive) ;
     }
     catch (const std::exception&)
     {

--- a/src/SerialStreamBuf.cpp
+++ b/src/SerialStreamBuf.cpp
@@ -69,13 +69,15 @@ namespace LibSerial
          * @param parityType The parity type for the serial stream.
          * @param stopBits The number of stop bits for the serial stream.
          * @param flowControlType The flow control type for the serial stream.
+         * @param exclusive Set exclusive access for the serial stream.
          */
         Implementation(const std::string&   fileName,
                        const BaudRate&      baudRate,
                        const CharacterSize& characterSize,
                        const FlowControl&   flowControlType,
                        const Parity&        parityType,
-                       const StopBits&      stopBits) ;
+                       const StopBits&      stopBits,
+                       bool                 exclusive) ;
 
         /**
          * @brief Copy construction is disallowed.
@@ -103,9 +105,11 @@ namespace LibSerial
          * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
+         * @param exclusive Set exclusive access for this serial port.
          */
         void Open(const std::string& fileName,
-                  const std::ios_base::openmode& openMode) ;
+                  const std::ios_base::openmode& openMode,
+                  bool exclusive) ;
 
         /**
          * @brief Closes the serial port. All settings of the serial port will be
@@ -390,13 +394,15 @@ namespace LibSerial
                                      const CharacterSize& characterSize,
                                      const FlowControl&   flowControlType,
                                      const Parity&        parityType,
-                                     const StopBits&      stopBits)
+                                     const StopBits&      stopBits,
+                                     bool                 exclusive)
         : mImpl(new Implementation(fileName,
                                    baudRate,
                                    characterSize,
                                    flowControlType,
                                    parityType,
-                                   stopBits))
+                                   stopBits,
+                                   exclusive))
     {
         setbuf(nullptr, 0) ;
     }
@@ -405,10 +411,12 @@ namespace LibSerial
 
     void
     SerialStreamBuf::Open(const std::string& fileName,
-                          const std::ios_base::openmode& openMode)
+                          const std::ios_base::openmode& openMode,
+                          bool exclusive)
     {
         mImpl->Open(fileName,
-                    openMode) ;
+                    openMode,
+                    exclusive) ;
     }
 
     void
@@ -656,13 +664,15 @@ namespace LibSerial
                                                     const CharacterSize& characterSize,
                                                     const FlowControl&   flowControlType,
                                                     const Parity&        parityType,
-                                                    const StopBits&      stopBits)
+                                                    const StopBits&      stopBits,
+                                                    bool                 exclusive)
     try : mSerialPort(fileName,
                       baudRate, 
                       characterSize,
                       flowControlType,
                       parityType,
-                      stopBits)
+                      stopBits,
+                      exclusive)
     {
         //  empty
     }
@@ -695,11 +705,13 @@ namespace LibSerial
     inline
     void
     SerialStreamBuf::Implementation::Open(const std::string& fileName,
-                                          const std::ios_base::openmode& openMode)
+                                          const std::ios_base::openmode& openMode,
+                                          bool exclusive)
     try
     {
         mSerialPort.Open(fileName, 
-                         openMode) ;
+                         openMode,
+                         exclusive) ;
 
         // @note - Stream communications need to happen in blocking mode.
         mSerialPort.SetSerialPortBlockingStatus(true) ;

--- a/src/libserial/SerialPort.h
+++ b/src/libserial/SerialPort.h
@@ -72,13 +72,15 @@ namespace LibSerial
          * @param parityType The parity type for the serial port.
          * @param stopBits The number of stop bits for the serial port.
          * @param flowControlType The flow control type for the serial port.
+         * @param exclusive Set exclusive access for the serial port.
          */
         explicit SerialPort(const std::string&   fileName,
                             const BaudRate&      baudRate        = BaudRate::BAUD_DEFAULT,
                             const CharacterSize& characterSize   = CharacterSize::CHAR_SIZE_DEFAULT,
                             const FlowControl&   flowControlType = FlowControl::FLOW_CONTROL_DEFAULT,
                             const Parity&        parityType      = Parity::PARITY_DEFAULT,
-                            const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT) ;
+                            const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT,
+                            bool                 exclusive       = true) ;
 
         /**
          * @brief Default Destructor for a SerialPort object. Closes the
@@ -112,9 +114,11 @@ namespace LibSerial
          * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
+         * @param exclusive Set exclusive access for the serial port.
          */
         void Open(const std::string& fileName,
-                  const std::ios_base::openmode& openMode = std::ios_base::in | std::ios_base::out) ;
+                  const std::ios_base::openmode& openMode = std::ios_base::in | std::ios_base::out,
+                  bool exclusive = true) ;
 
         /**
          * @brief Closes the serial port. All settings of the serial port will be

--- a/src/libserial/SerialStream.h
+++ b/src/libserial/SerialStream.h
@@ -96,13 +96,15 @@ namespace LibSerial
          * @param parityType The parity type for the serial stream.
          * @param stopBits The number of stop bits for the serial stream.
          * @param flowControlType The flow control type for the serial stream.
+         * @param exclusive Set exclusive access for the serial stream.
          */
         explicit SerialStream(const std::string&   fileName,
                               const BaudRate&      baudRate        = BaudRate::BAUD_DEFAULT,
                               const CharacterSize& characterSize   = CharacterSize::CHAR_SIZE_DEFAULT,
                               const FlowControl&   flowControlType = FlowControl::FLOW_CONTROL_DEFAULT,
                               const Parity&        parityType      = Parity::PARITY_DEFAULT,
-                              const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT) ;
+                              const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT,
+                              bool                 exclusive       = true) ;
 
         /**
          * @brief Default Destructor for a SerialStream object
@@ -140,9 +142,12 @@ namespace LibSerial
          * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
+         * @param exclusive Set exclusive access for this process to the
+         *        serial port.
          */
         void Open(const std::string& fileName,
-                  const std::ios_base::openmode& openMode = std::ios_base::in | std::ios_base::out) ;
+                  const std::ios_base::openmode& openMode = std::ios_base::in | std::ios_base::out,
+                  bool exclusive = true) ;
 
         /**
          * @brief Closes the serial port. All settings of the serial port will be

--- a/src/libserial/SerialStreamBuf.h
+++ b/src/libserial/SerialStreamBuf.h
@@ -75,13 +75,15 @@ namespace LibSerial
          * @param parityType The parity type for the serial stream.
          * @param stopBits The number of stop bits for the serial stream.
          * @param flowControlType The flow control type for the serial stream.
+         * @param exclusive Set exclusive access for the serial stream
          */
         explicit SerialStreamBuf(const std::string&   fileName,
                                  const BaudRate&      baudRate        = BaudRate::BAUD_DEFAULT,
                                  const CharacterSize& characterSize   = CharacterSize::CHAR_SIZE_DEFAULT,
                                  const FlowControl&   flowControlType = FlowControl::FLOW_CONTROL_DEFAULT,
                                  const Parity&        parityType      = Parity::PARITY_DEFAULT,
-                                 const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT) ;
+                                 const StopBits&      stopBits        = StopBits::STOP_BITS_DEFAULT,
+                                 bool                 exclusive       = true) ;
 
         /**
          * @brief Default Destructor for a SerialStreamBuf object. Closes the
@@ -115,9 +117,12 @@ namespace LibSerial
          * @param fileName The file name of the serial port.
          * @param openMode The communication mode status when the serial
          *        communication port is opened.
+         * @param exclusive Set exclusive access for this process to the
+         *        serial port.
          */
         void Open(const std::string& fileName,
-                  const std::ios_base::openmode& openMode = std::ios_base::in | std::ios_base::out) ;
+                  const std::ios_base::openmode& openMode = std::ios_base::in | std::ios_base::out,
+                  bool exclusive = true) ;
 
         /**
          * @brief Closes the serial port. All settings of the serial port will be


### PR DESCRIPTION
After ending program execution and closing the opened serial port, the serial port could not be opened again because it is busy. After some investigation, this could be tracked down to the exclusive access to the serial port which is being set in `Open(...)`.

To fix this, the serial port must be released from exclusive access in `Close()`:
```cpp
        // Release the serial port from exclusive access.
        if (mExclusiveAccess)
        {
            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg)
            if(call_with_retry(ioctl, this->mFileDescriptor, TIOCNXCL) == -1)
            {
                err_msg += ", ";
                err_msg += std::strerror(errno);
            }
        }
```

As an additional configuration option, I've added the `exclusive` flag that allows to specify whether to require exclusive access to the serial port or not.