### PR TITLE
Handle EINTR when calling tcdrain

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -967,7 +967,7 @@ namespace LibSerial
             throw NotOpen(ERR_MSG_PORT_NOT_OPEN) ;
         }
 
-        if (tcdrain(this->mFileDescriptor) < 0)
+        if (call_with_retry(tcdrain, this->mFileDescriptor) < 0)
         {
             throw std::runtime_error(std::strerror(errno)) ;
         }


### PR DESCRIPTION
As explained in the description of call_with_retry template, system calls that are interrupted and return EINTR shall be repeated. The original code occasionally throws an exception when writing data to the serial port.

This fixes https://github.com/crayzeewulf/libserial/issues/194