### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
 set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
 set(VERSION ${PROJECT_VERSION})
 configure_file(libserial.pc.in libserial.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libserial.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libserial.pc DESTINATION ${libdir}/pkgconfig)
 
 if (LIBSERIAL_BUILD_DOCS)
   CONFIGURE_FILE(


### PR DESCRIPTION
Install pkgconfig file into libdir, not sharedir.
Share is for architecture independent files, and the content of the pkgconf file is not arch independent.

See e.g. on amd64
prefix=/usr
exec_prefix=/usr
libdir=/usr/lib/x86_64-linux-gnu
includedir=/usr/include

Name: libserial
Description: C++ Serial port library
Version: 1.0.0
Libs: -L${libdir} -lserial
Cflags: -I${includedir}